### PR TITLE
ci: fix npm publishing

### DIFF
--- a/.github/workflows/publish-client.yml
+++ b/.github/workflows/publish-client.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  build-and-push-typescript-axios:
+  build-and-publish-github:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -44,11 +44,37 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  build-and-publish-npm:
+    runs-on: ubuntu-latest
+    needs: build-and-publish-github
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Set up Node for npm registry
         uses: actions/setup-node@v4
         with:
           node-version: "22.x"
           registry-url: "https://registry.npmjs.org"
+
+      - name: Set env
+        run: echo "TAG=0.$(date +'%Y%m%d.%H%M%S')" >> "$GITHUB_ENV"
+
+      - name: Generate Typescript Axios Client Library
+        uses: openapi-generators/openapitools-generator-action@v1
+        with:
+          generator: typescript-axios
+          openapi-file: api/api.yaml
+          generator-tag: v7.13.0
+          command-args: --additional-properties=npmName=@lwshen/vault-hub-ts-axios-client --additional-properties=npmVersion=${{ env.TAG }} --git-user-id lwshen --git-repo-id vault-hub
+
+      - name: Build package
+        run: |
+          cd typescript-axios-client
+          npm install
+          npm run build
 
       - name: Publish to npm registry
         run: |


### PR DESCRIPTION
- Renamed job from "build-and-push-typescript-axios" to "build-and-publish-github" for clarity.
- Added a new job "build-and-publish-npm" to generate and publish the Typescript Axios client library to npm.
- Included steps for setting environment variables, generating the client library, and building the package before publishing.