### PR TITLE
ci: use npm registry

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -48,5 +48,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          secrets: |
-            github_token=${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,14 +44,10 @@ jobs:
           node-version: "22"
           cache: "pnpm"
           cache-dependency-path: "./web/pnpm-lock.yaml"
-          registry-url: https://npm.pkg.github.com
-          scope: "@lwshen"
 
       - name: Install frontend dependencies
         working-directory: ./web
         run: pnpm install
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check frontend format
         working-directory: ./web

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -31,9 +31,6 @@ build:
 
     # Install frontend dependencies
     - cd ./web
-    # Configure npm authentication
-    - echo "//npm.pkg.github.com/:_authToken=${GITHUB_TOKEN}" >> $HOME/.npmrc
-    - echo "@lwshen:registry=https://npm.pkg.github.com" >> $HOME/.npmrc
     - pnpm install
 
     # Check frontend format

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,23 +9,7 @@ COPY web ./
 
 RUN corepack enable
 
-RUN --mount=type=secret,id=github_token \
-    GITHUB_TOKEN="" && \
-    if [ -f /run/secrets/github_token ]; then \
-        GITHUB_TOKEN=$(cat /run/secrets/github_token | tr -d '\n\r') && \
-        echo "Using GitHub token from secret"; \
-    elif [ -n "$GITHUB_TOKEN" ]; then \
-        echo "Using GitHub token from environment variable"; \
-    else \
-        echo "No GitHub token found, proceeding without private registry access"; \
-    fi && \
-    if [ -n "$GITHUB_TOKEN" ]; then \
-        echo "Setting up GitHub Package Registry authentication..." && \
-        echo "@lwshen:registry=https://npm.pkg.github.com" > .npmrc && \
-        echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> .npmrc && \
-        echo "GitHub token configured successfully"; \
-    fi && \
-    pnpm install --frozen-lockfile
+RUN pnpm install --frozen-lockfile
 
 RUN pnpm build
 

--- a/web/.npmrc
+++ b/web/.npmrc
@@ -1,1 +1,0 @@
-@lwshen:registry=https://npm.pkg.github.com

--- a/web/package.json
+++ b/web/package.json
@@ -12,7 +12,7 @@
     "typecheck": "tsc -b"
   },
   "dependencies": {
-    "@lwshen/vault-hub-ts-axios-client": "0.20250525.143813",
+    "@lwshen/vault-hub-ts-axios-client": "0.20250526.132212",
     "@radix-ui/react-dropdown-menu": "^2.1.14",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.2",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@lwshen/vault-hub-ts-axios-client':
-        specifier: 0.20250525.143813
-        version: 0.20250525.143813
+        specifier: 0.20250526.132212
+        version: 0.20250526.132212
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.14
         version: 2.1.14(@types/react-dom@19.1.5(@types/react@19.1.4))(@types/react@19.1.4)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -464,8 +464,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.25':
     resolution: {integrity: sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==}
 
-  '@lwshen/vault-hub-ts-axios-client@0.20250525.143813':
-    resolution: {integrity: sha512-/4cptu+dltet3ZMElyS0TyAdYe3Toj/+T6ntHISsyHnPwrDIV0PEj4dbRtf3pfQPpeAsci861SccfhTfdCNnvg==, tarball: https://npm.pkg.github.com/download/@lwshen/vault-hub-ts-axios-client/0.20250525.143813/fa6974fbadd41ca304dd5aeb38404794930ffe89}
+  '@lwshen/vault-hub-ts-axios-client@0.20250526.132212':
+    resolution: {integrity: sha512-Me9/jUu2fTc+uRG6r1k+3WRavbvbQ1IUcF5MTkEAmaIhqbjGuI1UORDxVaTmDXZwDR1WDqTftiZSVqjloRuVow==}
 
   '@modelcontextprotocol/sdk@1.11.0':
     resolution: {integrity: sha512-k/1pb70eD638anoi0e8wUGAlbMJXyvdV4p62Ko+EZ7eBe1xMx8Uhak1R5DgfoofsK5IBBnRwsYGTaLZl+6/+RQ==}
@@ -2689,7 +2689,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@lwshen/vault-hub-ts-axios-client@0.20250525.143813':
+  '@lwshen/vault-hub-ts-axios-client@0.20250526.132212':
     dependencies:
       axios: 1.9.0
     transitivePeerDependencies:

--- a/web/src/apis/api.ts
+++ b/web/src/apis/api.ts
@@ -1,5 +1,5 @@
-import { DefaultApi } from '@lwshen/vault-hub-ts-axios-client';
+import { AuthApi } from '@lwshen/vault-hub-ts-axios-client';
 
-const api = new DefaultApi();
+const authApi = new AuthApi();
 
-export default api;
+export { authApi };

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -1,4 +1,4 @@
-import api from '@/apis/api';
+import { authApi } from '@/apis/api';
 import { useState } from 'react';
 
 const useAuth = () => {
@@ -8,13 +8,13 @@ const useAuth = () => {
   
   // const login = () => setIsAuthenticated(true);
   const login = (email: string, password: string) => {
-    api.apiAuthLoginPost({
+    authApi.login({
       email,
       password
     });
   };
   const signup = (email: string, password: string, name: string) => {
-    api.apiAuthSignupPost({
+    authApi.signup({
       email,
       password,
       name


### PR DESCRIPTION
- Eliminated GitHub token configuration from the GitLab CI and Dockerfile to simplify the setup.
- Updated npm dependencies in package.json and pnpm-lock.yaml to the latest version.
- Removed the .npmrc file from the web directory as it is no longer needed.