### PR TITLE
fix: fix vault api response

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -254,10 +254,6 @@ components:
         unique_id:
           type: string
           description: Unique identifier for the vault
-        user_id:
-          type: integer
-          format: int64
-          description: ID of the user who owns this vault
         name:
           type: string
           description: Human-readable name


### PR DESCRIPTION
## Summary by Sourcery

Fix vault API responses by converting internal model.Vault objects to the API Vault type and removing the internal user_id field from the API schema

Enhancements:
- Add convertToApiVault helper to map model.Vault to the API Vault representation
- Update GetVaults, GetVault, CreateVault, and UpdateVault handlers to return API Vault objects instead of internal models

Documentation:
- Remove user_id property from the Vault schema in api.yaml to align with the API response