### PR TITLE
feat(backend): list vault by lite item

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -80,13 +80,6 @@ paths:
       tags:
         - Vault
       operationId: getVaults
-      parameters:
-        - name: category
-          in: query
-          description: Filter by category
-          required: false
-          schema:
-            type: string
       responses:
         '200':
           description: List of vaults

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -95,7 +95,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/Vault'
+                  $ref: '#/components/schemas/VaultLite'
     post:
       description: Create a new vault
       tags:
@@ -244,6 +244,28 @@ components:
         avatar:
           type: string
 
+    VaultLite:
+      type: object
+      required:
+        - unique_id
+        - name
+      properties:
+        unique_id:
+          type: string
+          description: Unique identifier for the vault
+        name:
+          type: string
+          description: Human-readable name
+        description:
+          type: string
+          description: Human-readable description
+        category:
+          type: string
+          description: Category/type of vault
+        updated_at:
+          type: string
+          format: date-time
+
     Vault:
       type: object
       required:
@@ -254,6 +276,10 @@ components:
         unique_id:
           type: string
           description: Unique identifier for the vault
+        user_id:
+          type: integer
+          format: int64
+          description: ID of the user who owns this vault
         name:
           type: string
           description: Human-readable name

--- a/api/generated.go
+++ b/api/generated.go
@@ -103,6 +103,22 @@ type Vault struct {
 	Value string `json:"value"`
 }
 
+// VaultLite defines model for VaultLite.
+type VaultLite struct {
+	// Category Category/type of vault
+	Category *string `json:"category,omitempty"`
+
+	// Description Human-readable description
+	Description *string `json:"description,omitempty"`
+
+	// Name Human-readable name
+	Name string `json:"name"`
+
+	// UniqueId Unique identifier for the vault
+	UniqueId  string     `json:"unique_id"`
+	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+}
+
 // GetVaultsParams defines parameters for GetVaults.
 type GetVaultsParams struct {
 	// Category Filter by category
@@ -402,7 +418,7 @@ type GetVaultsResponseObject interface {
 	VisitGetVaultsResponse(ctx *fiber.Ctx) error
 }
 
-type GetVaults200JSONResponse []Vault
+type GetVaults200JSONResponse []VaultLite
 
 func (response GetVaults200JSONResponse) VisitGetVaultsResponse(ctx *fiber.Ctx) error {
 	ctx.Response().Header.Set("Content-Type", "application/json")

--- a/api/vault.go
+++ b/api/vault.go
@@ -39,6 +39,7 @@ func getUserFromContext(c *fiber.Ctx) (*model.User, error) {
 
 // convertToApiVault converts a model.Vault to an api.Vault
 func convertToApiVault(vault *model.Vault) Vault {
+	// #nosec G115
 	userID := int64(vault.UserID)
 	return Vault{
 		UniqueId:    vault.UniqueID,
@@ -94,7 +95,7 @@ func (Server) GetVault(c *fiber.Ctx, uniqueID string) error {
 	}
 
 	var vault model.Vault
-	err = vault.GetByUniqueID(uniqueID, user.ID) // #nosec G115
+	err = vault.GetByUniqueID(uniqueID, user.ID)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return handler.SendError(c, fiber.StatusNotFound, "vault not found")
@@ -170,7 +171,7 @@ func (Server) UpdateVault(c *fiber.Ctx, uniqueID string) error {
 	}
 
 	var vault model.Vault
-	err = vault.GetByUniqueID(uniqueID, user.ID) // #nosec G115
+	err = vault.GetByUniqueID(uniqueID, user.ID)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return handler.SendError(c, fiber.StatusNotFound, "vault not found")
@@ -222,7 +223,7 @@ func (Server) DeleteVault(c *fiber.Ctx, uniqueID string) error {
 	}
 
 	var vault model.Vault
-	err = vault.GetByUniqueID(uniqueID, user.ID) // #nosec G115
+	err = vault.GetByUniqueID(uniqueID, user.ID)
 	if err != nil {
 		if err == gorm.ErrRecordNotFound {
 			return handler.SendError(c, fiber.StatusNotFound, "vault not found")

--- a/api/vault.go
+++ b/api/vault.go
@@ -65,15 +65,13 @@ func convertToApiVaultLite(vault *model.Vault) VaultLite {
 }
 
 // GetVaults handles GET /api/vaults
-func (Server) GetVaults(c *fiber.Ctx, params GetVaultsParams) error {
+func (Server) GetVaults(c *fiber.Ctx) error {
 	user, err := getUserFromContext(c)
 	if err != nil {
 		return err
 	}
 
-	category := getStringValue(params.Category)
-
-	vaults, err := model.GetVaultsByUser(user.ID, category, false)
+	vaults, err := model.GetVaultsByUser(user.ID, false)
 	if err != nil {
 		return handler.SendError(c, fiber.StatusInternalServerError, err.Error())
 	}

--- a/api/vault.go
+++ b/api/vault.go
@@ -39,13 +39,26 @@ func getUserFromContext(c *fiber.Ctx) (*model.User, error) {
 
 // convertToApiVault converts a model.Vault to an api.Vault
 func convertToApiVault(vault *model.Vault) Vault {
+	userID := int64(vault.UserID)
 	return Vault{
 		UniqueId:    vault.UniqueID,
+		UserId:      &userID,
 		Name:        vault.Name,
 		Value:       vault.Value,
 		Description: &vault.Description,
 		Category:    &vault.Category,
 		CreatedAt:   &vault.CreatedAt,
+		UpdatedAt:   &vault.UpdatedAt,
+	}
+}
+
+// convertToApiVaultLite converts a model.Vault to an api.VaultLite
+func convertToApiVaultLite(vault *model.Vault) VaultLite {
+	return VaultLite{
+		UniqueId:    vault.UniqueID,
+		Name:        vault.Name,
+		Description: &vault.Description,
+		Category:    &vault.Category,
 		UpdatedAt:   &vault.UpdatedAt,
 	}
 }
@@ -59,7 +72,7 @@ func (Server) GetVaults(c *fiber.Ctx, params GetVaultsParams) error {
 
 	category := getStringValue(params.Category)
 
-	vaults, err := model.GetVaultsByUser(user.ID, category)
+	vaults, err := model.GetVaultsByUser(user.ID, category, false)
 	if err != nil {
 		return handler.SendError(c, fiber.StatusInternalServerError, err.Error())
 	}
@@ -73,9 +86,9 @@ func (Server) GetVaults(c *fiber.Ctx, params GetVaultsParams) error {
 	}
 
 	// convert to api.Vault
-	apiVaults := make([]Vault, len(vaults))
+	apiVaults := make([]VaultLite, len(vaults))
 	for i, vault := range vaults {
-		apiVaults[i] = convertToApiVault(&vault)
+		apiVaults[i] = convertToApiVaultLite(&vault)
 	}
 
 	return c.Status(fiber.StatusOK).JSON(apiVaults)

--- a/api/vault.go
+++ b/api/vault.go
@@ -77,14 +77,6 @@ func (Server) GetVaults(c *fiber.Ctx, params GetVaultsParams) error {
 		return handler.SendError(c, fiber.StatusInternalServerError, err.Error())
 	}
 
-	// Log read action for each vault
-	ip, userAgent := getClientInfo(c)
-	for _, vault := range vaults {
-		if err := model.LogVaultAction(vault.ID, model.ActionReadVault, user.ID, ip, userAgent); err != nil {
-			slog.Error("Failed to create audit log for read vault", "error", err, "vaultID", vault.ID)
-		}
-	}
-
 	// convert to api.Vault
 	apiVaults := make([]VaultLite, len(vaults))
 	for i, vault := range vaults {

--- a/model/vault.go
+++ b/model/vault.go
@@ -158,13 +158,9 @@ func (v *Vault) GetByUniqueID(uniqueID string, userID uint) error {
 }
 
 // GetAllByUser retrieves all vaults for a user, optionally filtered by category
-func GetVaultsByUser(userID uint, category string, decrypt bool) ([]Vault, error) {
+func GetVaultsByUser(userID uint, decrypt bool) ([]Vault, error) {
 	var vaults []Vault
 	query := DB.Where("user_id = ?", userID)
-
-	if category != "" {
-		query = query.Where("category = ?", category)
-	}
 
 	err := query.Order("created_at DESC").Find(&vaults).Error
 	if err != nil {

--- a/model/vault.go
+++ b/model/vault.go
@@ -158,7 +158,7 @@ func (v *Vault) GetByUniqueID(uniqueID string, userID uint) error {
 }
 
 // GetAllByUser retrieves all vaults for a user, optionally filtered by category
-func GetVaultsByUser(userID uint, category string) ([]Vault, error) {
+func GetVaultsByUser(userID uint, category string, decrypt bool) ([]Vault, error) {
 	var vaults []Vault
 	query := DB.Where("user_id = ?", userID)
 
@@ -171,13 +171,15 @@ func GetVaultsByUser(userID uint, category string) ([]Vault, error) {
 		return nil, err
 	}
 
-	// Decrypt all values
-	for i := range vaults {
-		decryptedValue, err := encryption.Decrypt(vaults[i].Value)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decrypt value for vault %d: %w", vaults[i].ID, err)
+	// Decrypt all values if requested
+	if decrypt {
+		for i := range vaults {
+			decryptedValue, err := encryption.Decrypt(vaults[i].Value)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decrypt value for vault %d: %w", vaults[i].ID, err)
+			}
+			vaults[i].Value = decryptedValue
 		}
-		vaults[i].Value = decryptedValue
 	}
 
 	return vaults, nil


### PR DESCRIPTION
## Summary by Sourcery

Introduce a lightweight vault listing by defining a new VaultLite type and updating the GET /api/vaults endpoint, API spec, model, and generated code to return minimal vault details without decrypting values.

New Features:
- Add VaultLite schema to expose minimal vault fields in listing.
- Change GET /vaults to return a list of VaultLite items instead of full Vault objects.

Enhancements:
- Extend GetVaultsByUser with a decrypt flag to skip decryption when listing.
- Include user_id in the full Vault schema.
- Remove individual audit logging for vault reads in the listing endpoint.

Documentation:
- Update OpenAPI spec to define the VaultLite component and adjust the list vaults response schema accordingly.