### PR TITLE
refactor(api): use camel case in api schema

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,8 @@ The project uses OpenAPI 3.0 specification (`api/api.yaml`) with `oapi-codegen` 
 - Go server stubs (`api/generated.go`)
 - TypeScript client library (published as npm package)
 
+**Important**: Always run `go generate api/tool.go` after modifying `api/api.yaml` to regenerate the Go types and interfaces. The API spec uses camelCase naming convention for all properties (e.g., `uniqueId`, `createdAt`, `isActive`).
+
 ## Testing Strategy
 - Go unit tests for encryption (`internal/encryption/encryption_test.go`)
 - Database model tests (`model/db_test.go`)

--- a/api/api.yaml
+++ b/api/api.yaml
@@ -107,14 +107,14 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Vault'
-  /api/vaults/{unique_id}:
+  /api/vaults/{uniqueId}:
     get:
       description: Get a specific vault by Unique ID
       tags:
         - Vault
       operationId: getVault
       parameters:
-        - name: unique_id
+        - name: uniqueId
           in: path
           required: true
           description: Vault Unique ID
@@ -133,7 +133,7 @@ paths:
         - Vault
       operationId: updateVault
       parameters:
-        - name: unique_id
+        - name: uniqueId
           in: path
           required: true
           description: Vault Unique ID
@@ -158,7 +158,7 @@ paths:
         - Vault
       operationId: deleteVault
       parameters:
-        - name: unique_id
+        - name: uniqueId
           in: path
           required: true
           description: Vault Unique ID
@@ -174,21 +174,21 @@ paths:
         - Audit
       operationId: getAuditLogs
       parameters:
-        - name: start_date
+        - name: startDate
           in: query
           required: false
           description: Filter logs from this date (ISO 8601 format)
           schema:
             type: string
             format: date-time
-        - name: end_date
+        - name: endDate
           in: query
           required: false
           description: Filter logs until this date (ISO 8601 format)
           schema:
             type: string
             format: date-time
-        - name: vault_unique_id
+        - name: vaultUniqueId
           in: query
           required: false
           description: Filter logs by vault unique ID
@@ -383,10 +383,10 @@ components:
     VaultLite:
       type: object
       required:
-        - unique_id
+        - uniqueId
         - name
       properties:
-        unique_id:
+        uniqueId:
           type: string
           description: Unique identifier for the vault
         name:
@@ -398,21 +398,21 @@ components:
         category:
           type: string
           description: Category/type of vault
-        updated_at:
+        updatedAt:
           type: string
           format: date-time
 
     Vault:
       type: object
       required:
-        - unique_id
+        - uniqueId
         - name
         - value
       properties:
-        unique_id:
+        uniqueId:
           type: string
           description: Unique identifier for the vault
-        user_id:
+        userId:
           type: integer
           format: int64
           description: ID of the user who owns this vault
@@ -428,10 +428,10 @@ components:
         category:
           type: string
           description: Category/type of vault
-        created_at:
+        createdAt:
           type: string
           format: date-time
-        updated_at:
+        updatedAt:
           type: string
           format: date-time
 
@@ -483,16 +483,16 @@ components:
     AuditLogsResponse:
       type: object
       required:
-        - audit_logs
-        - total_count
+        - auditLogs
+        - totalCount
         - pageSize
         - pageIndex
       properties:
-        audit_logs:
+        auditLogs:
           type: array
           items:
             $ref: '#/components/schemas/AuditLog'
-        total_count:
+        totalCount:
           type: integer
           description: Total number of logs matching the filter criteria
         pageSize:
@@ -505,16 +505,16 @@ components:
     APIKeysResponse:
       type: object
       required:
-        - api_keys
-        - total_count
+        - apiKeys
+        - totalCount
         - pageSize
         - pageIndex
       properties:
-        api_keys:
+        apiKeys:
           type: array
           items:
             $ref: '#/components/schemas/APIKey'
-        total_count:
+        totalCount:
           type: integer
           description: Total number of API keys
         pageSize:
@@ -527,26 +527,26 @@ components:
     AuditLog:
       type: object
       required:
-        - created_at
-        - user_id
+        - createdAt
+        - userId
         - action
       properties:
-        created_at:
+        createdAt:
           type: string
           format: date-time
           description: When the action occurred
         vault:
           $ref: '#/components/schemas/VaultLite'
-        api_key:
+        apiKey:
           $ref: '#/components/schemas/APIKey'
         action:
           type: string
           enum: [read_vault, update_vault, delete_vault, create_vault, login_user, register_user, logout_user, create_api_key, update_api_key, delete_api_key]
           description: Type of action performed
-        ip_address:
+        ipAddress:
           type: string
           description: IP address from which the action was performed
-        user_agent:
+        userAgent:
           type: string
           description: User agent string from the client
 
@@ -555,8 +555,8 @@ components:
       required:
         - id
         - name
-        - is_active
-        - created_at
+        - isActive
+        - createdAt
       properties:
         id:
           type: integer
@@ -570,22 +570,22 @@ components:
           items:
             $ref: '#/components/schemas/VaultLite'
           description: Array of vaults this key can access (null/empty = all user's vaults)
-        expires_at:
+        expiresAt:
           type: string
           format: date-time
           description: Optional expiration date
-        last_used_at:
+        lastUsedAt:
           type: string
           format: date-time
           description: When the key was last used
-        is_active:
+        isActive:
           type: boolean
           description: Whether the key is currently active
-        created_at:
+        createdAt:
           type: string
           format: date-time
           description: When the key was created
-        updated_at:
+        updatedAt:
           type: string
           format: date-time
           description: When the key was last updated
@@ -600,12 +600,12 @@ components:
           description: Human-readable name for the API key
           minLength: 1
           maxLength: 255
-        vault_unique_ids:
+        vaultUniqueIds:
           type: array
           items:
             type: string
           description: Array of vault unique IDs this key can access (empty = all user's vaults)
-        expires_at:
+        expiresAt:
           type: string
           format: date-time
           description: Optional expiration date
@@ -613,10 +613,10 @@ components:
     CreateAPIKeyResponse:
       type: object
       required:
-        - api_key
+        - apiKey
         - key
       properties:
-        api_key:
+        apiKey:
           $ref: '#/components/schemas/APIKey'
         key:
           type: string
@@ -630,15 +630,15 @@ components:
           description: Human-readable name for the API key
           minLength: 1
           maxLength: 255
-        vault_unique_ids:
+        vaultUniqueIds:
           type: array
           items:
             type: string
           description: Array of vault unique IDs this key can access (empty = all user's vaults)
-        expires_at:
+        expiresAt:
           type: string
           format: date-time
           description: Optional expiration date
-        is_active:
+        isActive:
           type: boolean
           description: Enable or disable the API key

--- a/api/generated.go
+++ b/api/generated.go
@@ -31,25 +31,25 @@ const (
 // APIKey defines model for APIKey.
 type APIKey struct {
 	// CreatedAt When the key was created
-	CreatedAt time.Time `json:"created_at"`
+	CreatedAt time.Time `json:"createdAt"`
 
 	// ExpiresAt Optional expiration date
-	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
 
 	// Id Unique API key ID
 	Id int64 `json:"id"`
 
 	// IsActive Whether the key is currently active
-	IsActive bool `json:"is_active"`
+	IsActive bool `json:"isActive"`
 
 	// LastUsedAt When the key was last used
-	LastUsedAt *time.Time `json:"last_used_at,omitempty"`
+	LastUsedAt *time.Time `json:"lastUsedAt,omitempty"`
 
 	// Name Human-readable name for the API key
 	Name string `json:"name"`
 
 	// UpdatedAt When the key was last updated
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 
 	// Vaults Array of vaults this key can access (null/empty = all user's vaults)
 	Vaults *[]VaultLite `json:"vaults,omitempty"`
@@ -57,7 +57,7 @@ type APIKey struct {
 
 // APIKeysResponse defines model for APIKeysResponse.
 type APIKeysResponse struct {
-	ApiKeys []APIKey `json:"api_keys"`
+	ApiKeys []APIKey `json:"apiKeys"`
 
 	// PageIndex Current page index (starting from 1)
 	PageIndex int `json:"pageIndex"`
@@ -66,23 +66,23 @@ type APIKeysResponse struct {
 	PageSize int `json:"pageSize"`
 
 	// TotalCount Total number of API keys
-	TotalCount int `json:"total_count"`
+	TotalCount int `json:"totalCount"`
 }
 
 // AuditLog defines model for AuditLog.
 type AuditLog struct {
 	// Action Type of action performed
 	Action AuditLogAction `json:"action"`
-	ApiKey *APIKey        `json:"api_key,omitempty"`
+	ApiKey *APIKey        `json:"apiKey,omitempty"`
 
 	// CreatedAt When the action occurred
-	CreatedAt time.Time `json:"created_at"`
+	CreatedAt time.Time `json:"createdAt"`
 
 	// IpAddress IP address from which the action was performed
-	IpAddress *string `json:"ip_address,omitempty"`
+	IpAddress *string `json:"ipAddress,omitempty"`
 
 	// UserAgent User agent string from the client
-	UserAgent *string    `json:"user_agent,omitempty"`
+	UserAgent *string    `json:"userAgent,omitempty"`
 	Vault     *VaultLite `json:"vault,omitempty"`
 }
 
@@ -91,7 +91,7 @@ type AuditLogAction string
 
 // AuditLogsResponse defines model for AuditLogsResponse.
 type AuditLogsResponse struct {
-	AuditLogs []AuditLog `json:"audit_logs"`
+	AuditLogs []AuditLog `json:"auditLogs"`
 
 	// PageIndex Current page index (starting from 0)
 	PageIndex int `json:"pageIndex"`
@@ -100,24 +100,24 @@ type AuditLogsResponse struct {
 	PageSize int `json:"pageSize"`
 
 	// TotalCount Total number of logs matching the filter criteria
-	TotalCount int `json:"total_count"`
+	TotalCount int `json:"totalCount"`
 }
 
 // CreateAPIKeyRequest defines model for CreateAPIKeyRequest.
 type CreateAPIKeyRequest struct {
 	// ExpiresAt Optional expiration date
-	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
 
 	// Name Human-readable name for the API key
 	Name string `json:"name"`
 
 	// VaultUniqueIds Array of vault unique IDs this key can access (empty = all user's vaults)
-	VaultUniqueIds *[]string `json:"vault_unique_ids,omitempty"`
+	VaultUniqueIds *[]string `json:"vaultUniqueIds,omitempty"`
 }
 
 // CreateAPIKeyResponse defines model for CreateAPIKeyResponse.
 type CreateAPIKeyResponse struct {
-	ApiKey APIKey `json:"api_key"`
+	ApiKey APIKey `json:"apiKey"`
 
 	// Key The generated API key (only shown once)
 	Key string `json:"key"`
@@ -177,16 +177,16 @@ type SignupResponse struct {
 // UpdateAPIKeyRequest defines model for UpdateAPIKeyRequest.
 type UpdateAPIKeyRequest struct {
 	// ExpiresAt Optional expiration date
-	ExpiresAt *time.Time `json:"expires_at,omitempty"`
+	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
 
 	// IsActive Enable or disable the API key
-	IsActive *bool `json:"is_active,omitempty"`
+	IsActive *bool `json:"isActive,omitempty"`
 
 	// Name Human-readable name for the API key
 	Name *string `json:"name,omitempty"`
 
 	// VaultUniqueIds Array of vault unique IDs this key can access (empty = all user's vaults)
-	VaultUniqueIds *[]string `json:"vault_unique_ids,omitempty"`
+	VaultUniqueIds *[]string `json:"vaultUniqueIds,omitempty"`
 }
 
 // UpdateVaultRequest defines model for UpdateVaultRequest.
@@ -208,7 +208,7 @@ type UpdateVaultRequest struct {
 type Vault struct {
 	// Category Category/type of vault
 	Category  *string    `json:"category,omitempty"`
-	CreatedAt *time.Time `json:"created_at,omitempty"`
+	CreatedAt *time.Time `json:"createdAt,omitempty"`
 
 	// Description Human-readable description
 	Description *string `json:"description,omitempty"`
@@ -217,11 +217,11 @@ type Vault struct {
 	Name string `json:"name"`
 
 	// UniqueId Unique identifier for the vault
-	UniqueId  string     `json:"unique_id"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	UniqueId  string     `json:"uniqueId"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 
 	// UserId ID of the user who owns this vault
-	UserId *int64 `json:"user_id,omitempty"`
+	UserId *int64 `json:"userId,omitempty"`
 
 	// Value Encrypted value
 	Value string `json:"value"`
@@ -239,8 +239,8 @@ type VaultLite struct {
 	Name string `json:"name"`
 
 	// UniqueId Unique identifier for the vault
-	UniqueId  string     `json:"unique_id"`
-	UpdatedAt *time.Time `json:"updated_at,omitempty"`
+	UniqueId  string     `json:"uniqueId"`
+	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
 }
 
 // GetAPIKeysParams defines parameters for GetAPIKeys.
@@ -255,13 +255,13 @@ type GetAPIKeysParams struct {
 // GetAuditLogsParams defines parameters for GetAuditLogs.
 type GetAuditLogsParams struct {
 	// StartDate Filter logs from this date (ISO 8601 format)
-	StartDate *time.Time `form:"start_date,omitempty" json:"start_date,omitempty"`
+	StartDate *time.Time `form:"startDate,omitempty" json:"startDate,omitempty"`
 
 	// EndDate Filter logs until this date (ISO 8601 format)
-	EndDate *time.Time `form:"end_date,omitempty" json:"end_date,omitempty"`
+	EndDate *time.Time `form:"endDate,omitempty" json:"endDate,omitempty"`
 
 	// VaultUniqueId Filter logs by vault unique ID
-	VaultUniqueId *string `form:"vault_unique_id,omitempty" json:"vault_unique_id,omitempty"`
+	VaultUniqueId *string `form:"vaultUniqueId,omitempty" json:"vaultUniqueId,omitempty"`
 
 	// PageSize Number of logs per page (default 100, max 1000)
 	PageSize int `form:"pageSize" json:"pageSize"`
@@ -327,13 +327,13 @@ type ServerInterface interface {
 	// (POST /api/vaults)
 	CreateVault(c *fiber.Ctx) error
 
-	// (DELETE /api/vaults/{unique_id})
+	// (DELETE /api/vaults/{uniqueId})
 	DeleteVault(c *fiber.Ctx, uniqueId string) error
 
-	// (GET /api/vaults/{unique_id})
+	// (GET /api/vaults/{uniqueId})
 	GetVault(c *fiber.Ctx, uniqueId string) error
 
-	// (PUT /api/vaults/{unique_id})
+	// (PUT /api/vaults/{uniqueId})
 	UpdateVault(c *fiber.Ctx, uniqueId string) error
 }
 
@@ -443,25 +443,25 @@ func (siw *ServerInterfaceWrapper) GetAuditLogs(c *fiber.Ctx) error {
 		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for query string: %w", err).Error())
 	}
 
-	// ------------- Optional query parameter "start_date" -------------
+	// ------------- Optional query parameter "startDate" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "start_date", query, &params.StartDate)
+	err = runtime.BindQueryParameter("form", true, false, "startDate", query, &params.StartDate)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter start_date: %w", err).Error())
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter startDate: %w", err).Error())
 	}
 
-	// ------------- Optional query parameter "end_date" -------------
+	// ------------- Optional query parameter "endDate" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "end_date", query, &params.EndDate)
+	err = runtime.BindQueryParameter("form", true, false, "endDate", query, &params.EndDate)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter end_date: %w", err).Error())
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter endDate: %w", err).Error())
 	}
 
-	// ------------- Optional query parameter "vault_unique_id" -------------
+	// ------------- Optional query parameter "vaultUniqueId" -------------
 
-	err = runtime.BindQueryParameter("form", true, false, "vault_unique_id", query, &params.VaultUniqueId)
+	err = runtime.BindQueryParameter("form", true, false, "vaultUniqueId", query, &params.VaultUniqueId)
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter vault_unique_id: %w", err).Error())
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter vaultUniqueId: %w", err).Error())
 	}
 
 	// ------------- Required query parameter "pageSize" -------------
@@ -544,12 +544,12 @@ func (siw *ServerInterfaceWrapper) DeleteVault(c *fiber.Ctx) error {
 
 	var err error
 
-	// ------------- Path parameter "unique_id" -------------
+	// ------------- Path parameter "uniqueId" -------------
 	var uniqueId string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "unique_id", c.Params("unique_id"), &uniqueId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "uniqueId", c.Params("uniqueId"), &uniqueId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter unique_id: %w", err).Error())
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter uniqueId: %w", err).Error())
 	}
 
 	return siw.Handler.DeleteVault(c, uniqueId)
@@ -560,12 +560,12 @@ func (siw *ServerInterfaceWrapper) GetVault(c *fiber.Ctx) error {
 
 	var err error
 
-	// ------------- Path parameter "unique_id" -------------
+	// ------------- Path parameter "uniqueId" -------------
 	var uniqueId string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "unique_id", c.Params("unique_id"), &uniqueId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "uniqueId", c.Params("uniqueId"), &uniqueId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter unique_id: %w", err).Error())
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter uniqueId: %w", err).Error())
 	}
 
 	return siw.Handler.GetVault(c, uniqueId)
@@ -576,12 +576,12 @@ func (siw *ServerInterfaceWrapper) UpdateVault(c *fiber.Ctx) error {
 
 	var err error
 
-	// ------------- Path parameter "unique_id" -------------
+	// ------------- Path parameter "uniqueId" -------------
 	var uniqueId string
 
-	err = runtime.BindStyledParameterWithOptions("simple", "unique_id", c.Params("unique_id"), &uniqueId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
+	err = runtime.BindStyledParameterWithOptions("simple", "uniqueId", c.Params("uniqueId"), &uniqueId, runtime.BindStyledParameterOptions{Explode: false, Required: true})
 	if err != nil {
-		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter unique_id: %w", err).Error())
+		return fiber.NewError(fiber.StatusBadRequest, fmt.Errorf("Invalid format for parameter uniqueId: %w", err).Error())
 	}
 
 	return siw.Handler.UpdateVault(c, uniqueId)
@@ -632,11 +632,11 @@ func RegisterHandlersWithOptions(router fiber.Router, si ServerInterface, option
 
 	router.Post(options.BaseURL+"/api/vaults", wrapper.CreateVault)
 
-	router.Delete(options.BaseURL+"/api/vaults/:unique_id", wrapper.DeleteVault)
+	router.Delete(options.BaseURL+"/api/vaults/:uniqueId", wrapper.DeleteVault)
 
-	router.Get(options.BaseURL+"/api/vaults/:unique_id", wrapper.GetVault)
+	router.Get(options.BaseURL+"/api/vaults/:uniqueId", wrapper.GetVault)
 
-	router.Put(options.BaseURL+"/api/vaults/:unique_id", wrapper.UpdateVault)
+	router.Put(options.BaseURL+"/api/vaults/:uniqueId", wrapper.UpdateVault)
 
 }
 
@@ -840,7 +840,7 @@ func (response CreateVault201JSONResponse) VisitCreateVaultResponse(ctx *fiber.C
 }
 
 type DeleteVaultRequestObject struct {
-	UniqueId string `json:"unique_id"`
+	UniqueId string `json:"uniqueId"`
 }
 
 type DeleteVaultResponseObject interface {
@@ -856,7 +856,7 @@ func (response DeleteVault204Response) VisitDeleteVaultResponse(ctx *fiber.Ctx) 
 }
 
 type GetVaultRequestObject struct {
-	UniqueId string `json:"unique_id"`
+	UniqueId string `json:"uniqueId"`
 }
 
 type GetVaultResponseObject interface {
@@ -873,7 +873,7 @@ func (response GetVault200JSONResponse) VisitGetVaultResponse(ctx *fiber.Ctx) er
 }
 
 type UpdateVaultRequestObject struct {
-	UniqueId string `json:"unique_id"`
+	UniqueId string `json:"uniqueId"`
 	Body     *UpdateVaultJSONRequestBody
 }
 
@@ -929,13 +929,13 @@ type StrictServerInterface interface {
 	// (POST /api/vaults)
 	CreateVault(ctx context.Context, request CreateVaultRequestObject) (CreateVaultResponseObject, error)
 
-	// (DELETE /api/vaults/{unique_id})
+	// (DELETE /api/vaults/{uniqueId})
 	DeleteVault(ctx context.Context, request DeleteVaultRequestObject) (DeleteVaultResponseObject, error)
 
-	// (GET /api/vaults/{unique_id})
+	// (GET /api/vaults/{uniqueId})
 	GetVault(ctx context.Context, request GetVaultRequestObject) (GetVaultResponseObject, error)
 
-	// (PUT /api/vaults/{unique_id})
+	// (PUT /api/vaults/{uniqueId})
 	UpdateVault(ctx context.Context, request UpdateVaultRequestObject) (UpdateVaultResponseObject, error)
 }
 


### PR DESCRIPTION
- Updated API schema and generated Go code to use camelCase for parameter names, replacing snake_case (e.g., unique_id to uniqueId).
- Adjusted related request and response models to ensure consistency across the API.
- Enhanced documentation to reflect the updated naming conventions for better clarity and usability.

## Summary by Sourcery

Refactor the API schema and generated Go code to use camelCase naming for all JSON fields, path and query parameters, and OpenAPI schema properties.

Enhancements:
- Convert all JSON tags and struct fields in generated Go code to camelCase instead of snake_case
- Update path and query parameter names in route definitions and handler wrappers to use camelCase
- Regenerate request and response models and server interfaces to reflect camelCase naming
- Align OpenAPI spec (api.yaml) schema properties and parameter names with camelCase conventions

Documentation:
- Update API documentation to reflect the new camelCase naming conventions for parameters and schema fields