### PR TITLE
Split api.yaml and maintain go generate

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -314,331 +314,36 @@ paths:
 components:
   schemas:
     HealthCheckResponse:
-      type: object
-      properties:
-        status:
-          type: string
-          example: "ok"
-        timestamp:
-          type: string
-          format: date-time
-          example: "2023-10-11T12:34:56Z"
-
+      $ref: "./components/components.yaml#/components/schemas/HealthCheckResponse"
     LoginRequest:
-      type: object
-      required:
-        - email
-        - password
-      properties:
-        email:
-          type: string
-          format: email
-        password:
-          type: string
-
+      $ref: "./components/components.yaml#/components/schemas/LoginRequest"
     LoginResponse:
-      type: object
-      required:
-        - token
-      properties:
-        token:
-          type: string
-
+      $ref: "./components/components.yaml#/components/schemas/LoginResponse"
     SignupRequest:
-      type: object
-      required:
-        - email
-        - password
-        - name
-      properties:
-        email:
-          type: string
-          format: email
-        password:
-          type: string
-        name:
-          type: string
-
+      $ref: "./components/components.yaml#/components/schemas/SignupRequest"
     SignupResponse:
-      type: object
-      required:
-        - token
-      properties:
-        token:
-          type: string
-
+      $ref: "./components/components.yaml#/components/schemas/SignupResponse"
     GetUserResponse:
-      type: object
-      required:
-        - email
-      properties:
-        email:
-          type: string
-          format: email
-        name:
-          type: string
-        avatar:
-          type: string
-
+      $ref: "./components/components.yaml#/components/schemas/GetUserResponse"
     VaultLite:
-      type: object
-      required:
-        - uniqueId
-        - name
-      properties:
-        uniqueId:
-          type: string
-          description: Unique identifier for the vault
-        name:
-          type: string
-          description: Human-readable name
-        description:
-          type: string
-          description: Human-readable description
-        category:
-          type: string
-          description: Category/type of vault
-        updatedAt:
-          type: string
-          format: date-time
-
+      $ref: "./components/components.yaml#/components/schemas/VaultLite"
     Vault:
-      type: object
-      required:
-        - uniqueId
-        - name
-        - value
-      properties:
-        uniqueId:
-          type: string
-          description: Unique identifier for the vault
-        userId:
-          type: integer
-          format: int64
-          description: ID of the user who owns this vault
-        name:
-          type: string
-          description: Human-readable name
-        value:
-          type: string
-          description: Encrypted value
-        description:
-          type: string
-          description: Human-readable description
-        category:
-          type: string
-          description: Category/type of vault
-        createdAt:
-          type: string
-          format: date-time
-        updatedAt:
-          type: string
-          format: date-time
-
+      $ref: "./components/components.yaml#/components/schemas/Vault"
     CreateVaultRequest:
-      type: object
-      required:
-        - name
-        - value
-      properties:
-        name:
-          type: string
-          description: Human-readable name
-          minLength: 1
-          maxLength: 255
-        value:
-          type: string
-          description: Value to be encrypted and stored
-          minLength: 1
-        description:
-          type: string
-          description: Human-readable description
-          maxLength: 500
-        category:
-          type: string
-          description: Category/type of vault
-          maxLength: 100
-
+      $ref: "./components/components.yaml#/components/schemas/CreateVaultRequest"
     UpdateVaultRequest:
-      type: object
-      properties:
-        name:
-          type: string
-          description: Human-readable name
-          minLength: 1
-          maxLength: 255
-        value:
-          type: string
-          description: Value to be encrypted and stored
-          minLength: 1
-        description:
-          type: string
-          description: Human-readable description
-          maxLength: 500
-        category:
-          type: string
-          description: Category/type of vault
-          maxLength: 100
-
+      $ref: "./components/components.yaml#/components/schemas/UpdateVaultRequest"
     AuditLogsResponse:
-      type: object
-      required:
-        - auditLogs
-        - totalCount
-        - pageSize
-        - pageIndex
-      properties:
-        auditLogs:
-          type: array
-          items:
-            $ref: '#/components/schemas/AuditLog'
-        totalCount:
-          type: integer
-          description: Total number of logs matching the filter criteria
-        pageSize:
-          type: integer
-          description: Number of logs per page
-        pageIndex:
-          type: integer
-          description: Current page index (starting from 0)
-
+      $ref: "./components/components.yaml#/components/schemas/AuditLogsResponse"
     APIKeysResponse:
-      type: object
-      required:
-        - apiKeys
-        - totalCount
-        - pageSize
-        - pageIndex
-      properties:
-        apiKeys:
-          type: array
-          items:
-            $ref: '#/components/schemas/APIKey'
-        totalCount:
-          type: integer
-          description: Total number of API keys
-        pageSize:
-          type: integer
-          description: Number of API keys per page
-        pageIndex:
-          type: integer
-          description: Current page index (starting from 1)
-
+      $ref: "./components/components.yaml#/components/schemas/APIKeysResponse"
     AuditLog:
-      type: object
-      required:
-        - createdAt
-        - userId
-        - action
-      properties:
-        createdAt:
-          type: string
-          format: date-time
-          description: When the action occurred
-        vault:
-          $ref: '#/components/schemas/VaultLite'
-        apiKey:
-          $ref: '#/components/schemas/APIKey'
-        action:
-          type: string
-          enum: [read_vault, update_vault, delete_vault, create_vault, login_user, register_user, logout_user, create_api_key, update_api_key, delete_api_key]
-          description: Type of action performed
-        ipAddress:
-          type: string
-          description: IP address from which the action was performed
-        userAgent:
-          type: string
-          description: User agent string from the client
-
+      $ref: "./components/components.yaml#/components/schemas/AuditLog"
     APIKey:
-      type: object
-      required:
-        - id
-        - name
-        - isActive
-        - createdAt
-      properties:
-        id:
-          type: integer
-          format: int64
-          description: Unique API key ID
-        name:
-          type: string
-          description: Human-readable name for the API key
-        vaults:
-          type: array
-          items:
-            $ref: '#/components/schemas/VaultLite'
-          description: Array of vaults this key can access (null/empty = all user's vaults)
-        expiresAt:
-          type: string
-          format: date-time
-          description: Optional expiration date
-        lastUsedAt:
-          type: string
-          format: date-time
-          description: When the key was last used
-        isActive:
-          type: boolean
-          description: Whether the key is currently active
-        createdAt:
-          type: string
-          format: date-time
-          description: When the key was created
-        updatedAt:
-          type: string
-          format: date-time
-          description: When the key was last updated
-
+      $ref: "./components/components.yaml#/components/schemas/APIKey"
     CreateAPIKeyRequest:
-      type: object
-      required:
-        - name
-      properties:
-        name:
-          type: string
-          description: Human-readable name for the API key
-          minLength: 1
-          maxLength: 255
-        vaultUniqueIds:
-          type: array
-          items:
-            type: string
-          description: Array of vault unique IDs this key can access (empty = all user's vaults)
-        expiresAt:
-          type: string
-          format: date-time
-          description: Optional expiration date
-
+      $ref: "./components/components.yaml#/components/schemas/CreateAPIKeyRequest"
     CreateAPIKeyResponse:
-      type: object
-      required:
-        - apiKey
-        - key
-      properties:
-        apiKey:
-          $ref: '#/components/schemas/APIKey'
-        key:
-          type: string
-          description: The generated API key (only shown once)
-
+      $ref: "./components/components.yaml#/components/schemas/CreateAPIKeyResponse"
     UpdateAPIKeyRequest:
-      type: object
-      properties:
-        name:
-          type: string
-          description: Human-readable name for the API key
-          minLength: 1
-          maxLength: 255
-        vaultUniqueIds:
-          type: array
-          items:
-            type: string
-          description: Array of vault unique IDs this key can access (empty = all user's vaults)
-        expiresAt:
-          type: string
-          format: date-time
-          description: Optional expiration date
-        isActive:
-          type: boolean
-          description: Enable or disable the API key
+      $ref: "./components/components.yaml#/components/schemas/UpdateAPIKeyRequest"

--- a/api/cfg.yaml
+++ b/api/cfg.yaml
@@ -4,3 +4,5 @@ generate:
   fiber-server: true
   strict-server: true
 output: generated.go
+import-mapping:
+  ./components/components.yaml: github.com/lwshen/vault-hub/api

--- a/api/components/components.yaml
+++ b/api/components/components.yaml
@@ -1,0 +1,331 @@
+components:
+  schemas:
+    HealthCheckResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: "ok"
+        timestamp:
+          type: string
+          format: date-time
+          example: "2023-10-11T12:34:56Z"
+
+    LoginRequest:
+      type: object
+      required:
+        - email
+        - password
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+
+    LoginResponse:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: string
+
+    SignupRequest:
+      type: object
+      required:
+        - email
+        - password
+        - name
+      properties:
+        email:
+          type: string
+          format: email
+        password:
+          type: string
+        name:
+          type: string
+
+    SignupResponse:
+      type: object
+      required:
+        - token
+      properties:
+        token:
+          type: string
+
+    GetUserResponse:
+      type: object
+      required:
+        - email
+      properties:
+        email:
+          type: string
+          format: email
+        name:
+          type: string
+        avatar:
+          type: string
+
+    VaultLite:
+      type: object
+      required:
+        - uniqueId
+        - name
+      properties:
+        uniqueId:
+          type: string
+          description: Unique identifier for the vault
+        name:
+          type: string
+          description: Human-readable name
+        description:
+          type: string
+          description: Human-readable description
+        category:
+          type: string
+          description: Category/type of vault
+        updatedAt:
+          type: string
+          format: date-time
+
+    Vault:
+      type: object
+      required:
+        - uniqueId
+        - name
+        - value
+      properties:
+        uniqueId:
+          type: string
+          description: Unique identifier for the vault
+        userId:
+          type: integer
+          format: int64
+          description: ID of the user who owns this vault
+        name:
+          type: string
+          description: Human-readable name
+        value:
+          type: string
+          description: Encrypted value
+        description:
+          type: string
+          description: Human-readable description
+        category:
+          type: string
+          description: Category/type of vault
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+
+    CreateVaultRequest:
+      type: object
+      required:
+        - name
+        - value
+      properties:
+        name:
+          type: string
+          description: Human-readable name
+          minLength: 1
+          maxLength: 255
+        value:
+          type: string
+          description: Value to be encrypted and stored
+          minLength: 1
+        description:
+          type: string
+          description: Human-readable description
+          maxLength: 500
+        category:
+          type: string
+          description: Category/type of vault
+          maxLength: 100
+
+    UpdateVaultRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Human-readable name
+          minLength: 1
+          maxLength: 255
+        value:
+          type: string
+          description: Value to be encrypted and stored
+          minLength: 1
+        description:
+          type: string
+          description: Human-readable description
+          maxLength: 500
+        category:
+          type: string
+          description: Category/type of vault
+          maxLength: 100
+
+    AuditLogsResponse:
+      type: object
+      required:
+        - auditLogs
+        - totalCount
+        - pageSize
+        - pageIndex
+      properties:
+        auditLogs:
+          type: array
+          items:
+            $ref: '#/components/schemas/AuditLog'
+        totalCount:
+          type: integer
+          description: Total number of logs matching the filter criteria
+        pageSize:
+          type: integer
+          description: Number of logs per page
+        pageIndex:
+          type: integer
+          description: Current page index (starting from 0)
+
+    APIKeysResponse:
+      type: object
+      required:
+        - apiKeys
+        - totalCount
+        - pageSize
+        - pageIndex
+      properties:
+        apiKeys:
+          type: array
+          items:
+            $ref: '#/components/schemas/APIKey'
+        totalCount:
+          type: integer
+          description: Total number of API keys
+        pageSize:
+          type: integer
+          description: Number of API keys per page
+        pageIndex:
+          type: integer
+          description: Current page index (starting from 1)
+
+    AuditLog:
+      type: object
+      required:
+        - createdAt
+        - userId
+        - action
+      properties:
+        createdAt:
+          type: string
+          format: date-time
+          description: When the action occurred
+        vault:
+          $ref: '#/components/schemas/VaultLite'
+        apiKey:
+          $ref: '#/components/schemas/APIKey'
+        action:
+          type: string
+          enum: [read_vault, update_vault, delete_vault, create_vault, login_user, register_user, logout_user, create_api_key, update_api_key, delete_api_key]
+          description: Type of action performed
+        ipAddress:
+          type: string
+          description: IP address from which the action was performed
+        userAgent:
+          type: string
+          description: User agent string from the client
+
+    APIKey:
+      type: object
+      required:
+        - id
+        - name
+        - isActive
+        - createdAt
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Unique API key ID
+        name:
+          type: string
+          description: Human-readable name for the API key
+        vaults:
+          type: array
+          items:
+            $ref: '#/components/schemas/VaultLite'
+          description: Array of vaults this key can access (null/empty = all user's vaults)
+        expiresAt:
+          type: string
+          format: date-time
+          description: Optional expiration date
+        lastUsedAt:
+          type: string
+          format: date-time
+          description: When the key was last used
+        isActive:
+          type: boolean
+          description: Whether the key is currently active
+        createdAt:
+          type: string
+          format: date-time
+          description: When the key was created
+        updatedAt:
+          type: string
+          format: date-time
+          description: When the key was last updated
+
+    CreateAPIKeyRequest:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: Human-readable name for the API key
+          minLength: 1
+          maxLength: 255
+        vaultUniqueIds:
+          type: array
+          items:
+            type: string
+          description: Array of vault unique IDs this key can access (empty = all user's vaults)
+        expiresAt:
+          type: string
+          format: date-time
+          description: Optional expiration date
+
+    CreateAPIKeyResponse:
+      type: object
+      required:
+        - apiKey
+        - key
+      properties:
+        apiKey:
+          $ref: '#/components/schemas/APIKey'
+        key:
+          type: string
+          description: The generated API key (only shown once)
+
+    UpdateAPIKeyRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          description: Human-readable name for the API key
+          minLength: 1
+          maxLength: 255
+        vaultUniqueIds:
+          type: array
+          items:
+            type: string
+          description: Array of vault unique IDs this key can access (empty = all user's vaults)
+        expiresAt:
+          type: string
+          format: date-time
+          description: Optional expiration date
+        isActive:
+          type: boolean
+          description: Enable or disable the API key

--- a/api/generated.go
+++ b/api/generated.go
@@ -10,238 +10,57 @@ import (
 	"time"
 
 	"github.com/gofiber/fiber/v2"
+	externalRef0 "github.com/lwshen/vault-hub/api"
 	"github.com/oapi-codegen/runtime"
-	openapi_types "github.com/oapi-codegen/runtime/types"
-)
-
-// Defines values for AuditLogAction.
-const (
-	CreateApiKey AuditLogAction = "create_api_key"
-	CreateVault  AuditLogAction = "create_vault"
-	DeleteApiKey AuditLogAction = "delete_api_key"
-	DeleteVault  AuditLogAction = "delete_vault"
-	LoginUser    AuditLogAction = "login_user"
-	LogoutUser   AuditLogAction = "logout_user"
-	ReadVault    AuditLogAction = "read_vault"
-	RegisterUser AuditLogAction = "register_user"
-	UpdateApiKey AuditLogAction = "update_api_key"
-	UpdateVault  AuditLogAction = "update_vault"
 )
 
 // APIKey defines model for APIKey.
-type APIKey struct {
-	// CreatedAt When the key was created
-	CreatedAt time.Time `json:"createdAt"`
-
-	// ExpiresAt Optional expiration date
-	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
-
-	// Id Unique API key ID
-	Id int64 `json:"id"`
-
-	// IsActive Whether the key is currently active
-	IsActive bool `json:"isActive"`
-
-	// LastUsedAt When the key was last used
-	LastUsedAt *time.Time `json:"lastUsedAt,omitempty"`
-
-	// Name Human-readable name for the API key
-	Name string `json:"name"`
-
-	// UpdatedAt When the key was last updated
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
-
-	// Vaults Array of vaults this key can access (null/empty = all user's vaults)
-	Vaults *[]VaultLite `json:"vaults,omitempty"`
-}
+type APIKey = externalRef0.APIKey
 
 // APIKeysResponse defines model for APIKeysResponse.
-type APIKeysResponse struct {
-	ApiKeys []APIKey `json:"apiKeys"`
-
-	// PageIndex Current page index (starting from 1)
-	PageIndex int `json:"pageIndex"`
-
-	// PageSize Number of API keys per page
-	PageSize int `json:"pageSize"`
-
-	// TotalCount Total number of API keys
-	TotalCount int `json:"totalCount"`
-}
-
-// AuditLog defines model for AuditLog.
-type AuditLog struct {
-	// Action Type of action performed
-	Action AuditLogAction `json:"action"`
-	ApiKey *APIKey        `json:"apiKey,omitempty"`
-
-	// CreatedAt When the action occurred
-	CreatedAt time.Time `json:"createdAt"`
-
-	// IpAddress IP address from which the action was performed
-	IpAddress *string `json:"ipAddress,omitempty"`
-
-	// UserAgent User agent string from the client
-	UserAgent *string    `json:"userAgent,omitempty"`
-	Vault     *VaultLite `json:"vault,omitempty"`
-}
-
-// AuditLogAction Type of action performed
-type AuditLogAction string
+type APIKeysResponse = externalRef0.APIKeysResponse
 
 // AuditLogsResponse defines model for AuditLogsResponse.
-type AuditLogsResponse struct {
-	AuditLogs []AuditLog `json:"auditLogs"`
-
-	// PageIndex Current page index (starting from 0)
-	PageIndex int `json:"pageIndex"`
-
-	// PageSize Number of logs per page
-	PageSize int `json:"pageSize"`
-
-	// TotalCount Total number of logs matching the filter criteria
-	TotalCount int `json:"totalCount"`
-}
+type AuditLogsResponse = externalRef0.AuditLogsResponse
 
 // CreateAPIKeyRequest defines model for CreateAPIKeyRequest.
-type CreateAPIKeyRequest struct {
-	// ExpiresAt Optional expiration date
-	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
-
-	// Name Human-readable name for the API key
-	Name string `json:"name"`
-
-	// VaultUniqueIds Array of vault unique IDs this key can access (empty = all user's vaults)
-	VaultUniqueIds *[]string `json:"vaultUniqueIds,omitempty"`
-}
+type CreateAPIKeyRequest = externalRef0.CreateAPIKeyRequest
 
 // CreateAPIKeyResponse defines model for CreateAPIKeyResponse.
-type CreateAPIKeyResponse struct {
-	ApiKey APIKey `json:"apiKey"`
-
-	// Key The generated API key (only shown once)
-	Key string `json:"key"`
-}
+type CreateAPIKeyResponse = externalRef0.CreateAPIKeyResponse
 
 // CreateVaultRequest defines model for CreateVaultRequest.
-type CreateVaultRequest struct {
-	// Category Category/type of vault
-	Category *string `json:"category,omitempty"`
-
-	// Description Human-readable description
-	Description *string `json:"description,omitempty"`
-
-	// Name Human-readable name
-	Name string `json:"name"`
-
-	// Value Value to be encrypted and stored
-	Value string `json:"value"`
-}
+type CreateVaultRequest = externalRef0.CreateVaultRequest
 
 // GetUserResponse defines model for GetUserResponse.
-type GetUserResponse struct {
-	Avatar *string             `json:"avatar,omitempty"`
-	Email  openapi_types.Email `json:"email"`
-	Name   *string             `json:"name,omitempty"`
-}
+type GetUserResponse = externalRef0.GetUserResponse
 
 // HealthCheckResponse defines model for HealthCheckResponse.
-type HealthCheckResponse struct {
-	Status    *string    `json:"status,omitempty"`
-	Timestamp *time.Time `json:"timestamp,omitempty"`
-}
+type HealthCheckResponse = externalRef0.HealthCheckResponse
 
 // LoginRequest defines model for LoginRequest.
-type LoginRequest struct {
-	Email    openapi_types.Email `json:"email"`
-	Password string              `json:"password"`
-}
+type LoginRequest = externalRef0.LoginRequest
 
 // LoginResponse defines model for LoginResponse.
-type LoginResponse struct {
-	Token string `json:"token"`
-}
+type LoginResponse = externalRef0.LoginResponse
 
 // SignupRequest defines model for SignupRequest.
-type SignupRequest struct {
-	Email    openapi_types.Email `json:"email"`
-	Name     string              `json:"name"`
-	Password string              `json:"password"`
-}
+type SignupRequest = externalRef0.SignupRequest
 
 // SignupResponse defines model for SignupResponse.
-type SignupResponse struct {
-	Token string `json:"token"`
-}
+type SignupResponse = externalRef0.SignupResponse
 
 // UpdateAPIKeyRequest defines model for UpdateAPIKeyRequest.
-type UpdateAPIKeyRequest struct {
-	// ExpiresAt Optional expiration date
-	ExpiresAt *time.Time `json:"expiresAt,omitempty"`
-
-	// IsActive Enable or disable the API key
-	IsActive *bool `json:"isActive,omitempty"`
-
-	// Name Human-readable name for the API key
-	Name *string `json:"name,omitempty"`
-
-	// VaultUniqueIds Array of vault unique IDs this key can access (empty = all user's vaults)
-	VaultUniqueIds *[]string `json:"vaultUniqueIds,omitempty"`
-}
+type UpdateAPIKeyRequest = externalRef0.UpdateAPIKeyRequest
 
 // UpdateVaultRequest defines model for UpdateVaultRequest.
-type UpdateVaultRequest struct {
-	// Category Category/type of vault
-	Category *string `json:"category,omitempty"`
-
-	// Description Human-readable description
-	Description *string `json:"description,omitempty"`
-
-	// Name Human-readable name
-	Name *string `json:"name,omitempty"`
-
-	// Value Value to be encrypted and stored
-	Value *string `json:"value,omitempty"`
-}
+type UpdateVaultRequest = externalRef0.UpdateVaultRequest
 
 // Vault defines model for Vault.
-type Vault struct {
-	// Category Category/type of vault
-	Category  *string    `json:"category,omitempty"`
-	CreatedAt *time.Time `json:"createdAt,omitempty"`
-
-	// Description Human-readable description
-	Description *string `json:"description,omitempty"`
-
-	// Name Human-readable name
-	Name string `json:"name"`
-
-	// UniqueId Unique identifier for the vault
-	UniqueId  string     `json:"uniqueId"`
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
-
-	// UserId ID of the user who owns this vault
-	UserId *int64 `json:"userId,omitempty"`
-
-	// Value Encrypted value
-	Value string `json:"value"`
-}
+type Vault = externalRef0.Vault
 
 // VaultLite defines model for VaultLite.
-type VaultLite struct {
-	// Category Category/type of vault
-	Category *string `json:"category,omitempty"`
-
-	// Description Human-readable description
-	Description *string `json:"description,omitempty"`
-
-	// Name Human-readable name
-	Name string `json:"name"`
-
-	// UniqueId Unique identifier for the vault
-	UniqueId  string     `json:"uniqueId"`
-	UpdatedAt *time.Time `json:"updatedAt,omitempty"`
-}
+type VaultLite = externalRef0.VaultLite
 
 // GetAPIKeysParams defines parameters for GetAPIKeys.
 type GetAPIKeysParams struct {


### PR DESCRIPTION
Split OpenAPI schema definitions into `api/components/components.yaml` for better organization and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-012254e9-e0fc-40d9-90cd-7965e9959304">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-012254e9-e0fc-40d9-90cd-7965e9959304">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Split OpenAPI schemas into a dedicated components file, update API YAML to reference them via $ref, and adjust code generation to alias models from the external API package.

Enhancements:
- Extract all schema definitions into api/components/components.yaml and update api/api.yaml to reference them via $ref
- Refactor generated.go to remove inline model definitions and replace them with type aliases to the external API package
- Add import-mapping in api/cfg.yaml to support external type references during go generate