### PR TITLE
Split api.yaml and maintain go generate

### DIFF
--- a/api/api.yaml
+++ b/api/api.yaml
@@ -25,7 +25,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/LoginRequest"
+              $ref: '#/components/schemas/LoginRequest'
       responses:
         '200':
           description: Login successfully
@@ -44,7 +44,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/SignupRequest"
+              $ref: '#/components/schemas/SignupRequest'
       responses:
         '200':
           description: Sign up successfully
@@ -99,7 +99,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateVaultRequest"
+              $ref: '#/components/schemas/CreateVaultRequest'
       responses:
         '201':
           description: Vault created successfully
@@ -144,7 +144,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateVaultRequest"
+              $ref: '#/components/schemas/UpdateVaultRequest'
       responses:
         '200':
           description: Vault updated successfully
@@ -259,7 +259,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/CreateAPIKeyRequest"
+              $ref: '#/components/schemas/CreateAPIKeyRequest'
       responses:
         '201':
           description: API key created successfully
@@ -286,7 +286,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/UpdateAPIKeyRequest"
+              $ref: '#/components/schemas/UpdateAPIKeyRequest'
       responses:
         '200':
           description: API key updated successfully
@@ -310,7 +310,6 @@ paths:
       responses:
         '204':
           description: API key deleted successfully
-
 components:
   schemas:
     HealthCheckResponse:
@@ -318,12 +317,11 @@ components:
       properties:
         status:
           type: string
-          example: "ok"
+          example: ok
         timestamp:
           type: string
           format: date-time
-          example: "2023-10-11T12:34:56Z"
-
+          example: '2023-10-11T12:34:56Z'
     LoginRequest:
       type: object
       required:
@@ -335,7 +333,6 @@ components:
           format: email
         password:
           type: string
-
     LoginResponse:
       type: object
       required:
@@ -343,7 +340,6 @@ components:
       properties:
         token:
           type: string
-
     SignupRequest:
       type: object
       required:
@@ -358,7 +354,6 @@ components:
           type: string
         name:
           type: string
-
     SignupResponse:
       type: object
       required:
@@ -366,7 +361,6 @@ components:
       properties:
         token:
           type: string
-
     GetUserResponse:
       type: object
       required:
@@ -379,7 +373,6 @@ components:
           type: string
         avatar:
           type: string
-
     VaultLite:
       type: object
       required:
@@ -401,7 +394,6 @@ components:
         updatedAt:
           type: string
           format: date-time
-
     Vault:
       type: object
       required:
@@ -434,7 +426,6 @@ components:
         updatedAt:
           type: string
           format: date-time
-
     CreateVaultRequest:
       type: object
       required:
@@ -458,7 +449,6 @@ components:
           type: string
           description: Category/type of vault
           maxLength: 100
-
     UpdateVaultRequest:
       type: object
       properties:
@@ -479,7 +469,6 @@ components:
           type: string
           description: Category/type of vault
           maxLength: 100
-
     AuditLogsResponse:
       type: object
       required:
@@ -501,7 +490,6 @@ components:
         pageIndex:
           type: integer
           description: Current page index (starting from 0)
-
     APIKeysResponse:
       type: object
       required:
@@ -523,7 +511,6 @@ components:
         pageIndex:
           type: integer
           description: Current page index (starting from 1)
-
     AuditLog:
       type: object
       required:
@@ -541,7 +528,17 @@ components:
           $ref: '#/components/schemas/APIKey'
         action:
           type: string
-          enum: [read_vault, update_vault, delete_vault, create_vault, login_user, register_user, logout_user, create_api_key, update_api_key, delete_api_key]
+          enum:
+            - read_vault
+            - update_vault
+            - delete_vault
+            - create_vault
+            - login_user
+            - register_user
+            - logout_user
+            - create_api_key
+            - update_api_key
+            - delete_api_key
           description: Type of action performed
         ipAddress:
           type: string
@@ -549,7 +546,6 @@ components:
         userAgent:
           type: string
           description: User agent string from the client
-
     APIKey:
       type: object
       required:
@@ -589,7 +585,6 @@ components:
           type: string
           format: date-time
           description: When the key was last updated
-
     CreateAPIKeyRequest:
       type: object
       required:
@@ -609,7 +604,6 @@ components:
           type: string
           format: date-time
           description: Optional expiration date
-
     CreateAPIKeyResponse:
       type: object
       required:
@@ -621,7 +615,6 @@ components:
         key:
           type: string
           description: The generated API key (only shown once)
-
     UpdateAPIKeyRequest:
       type: object
       properties:

--- a/api/openapi/main.yaml
+++ b/api/openapi/main.yaml
@@ -1,0 +1,62 @@
+openapi: 3.0.0
+info:
+  version: 1.0.0
+  title: Vault Hub Server
+paths:
+  /api/health:
+    $ref: './paths/health.yaml#/~1api~1health'
+  /api/auth/login:
+    $ref: './paths/auth.yaml#/~1api~1auth~1login'
+  /api/auth/signup:
+    $ref: './paths/auth.yaml#/~1api~1auth~1signup'
+  /api/auth/logout:
+    $ref: './paths/auth.yaml#/~1api~1auth~1logout'
+  /api/user:
+    $ref: './paths/user.yaml#/~1api~1user'
+  /api/vaults:
+    $ref: './paths/vault.yaml#/~1api~1vaults'
+  /api/vaults/{uniqueId}:
+    $ref: './paths/vault.yaml#/~1api~1vaults~1{uniqueId}'
+  /api/audit-logs:
+    $ref: './paths/audit.yaml#/~1api~1audit-logs'
+  /api/api-keys:
+    $ref: './paths/apikey.yaml#/~1api~1api-keys'
+  /api/api-keys/{id}:
+    $ref: './paths/apikey.yaml#/~1api~1api-keys~1{id}'
+
+components:
+  schemas:
+    HealthCheckResponse:
+      $ref: './schemas/health.yaml#/HealthCheckResponse'
+    LoginRequest:
+      $ref: './schemas/auth.yaml#/LoginRequest'
+    LoginResponse:
+      $ref: './schemas/auth.yaml#/LoginResponse'
+    SignupRequest:
+      $ref: './schemas/auth.yaml#/SignupRequest'
+    SignupResponse:
+      $ref: './schemas/auth.yaml#/SignupResponse'
+    GetUserResponse:
+      $ref: './schemas/user.yaml#/GetUserResponse'
+    VaultLite:
+      $ref: './schemas/vault.yaml#/VaultLite'
+    Vault:
+      $ref: './schemas/vault.yaml#/Vault'
+    CreateVaultRequest:
+      $ref: './schemas/vault.yaml#/CreateVaultRequest'
+    UpdateVaultRequest:
+      $ref: './schemas/vault.yaml#/UpdateVaultRequest'
+    AuditLogsResponse:
+      $ref: './schemas/audit.yaml#/AuditLogsResponse'
+    APIKeysResponse:
+      $ref: './schemas/apikey.yaml#/APIKeysResponse'
+    AuditLog:
+      $ref: './schemas/audit.yaml#/AuditLog'
+    APIKey:
+      $ref: './schemas/apikey.yaml#/APIKey'
+    CreateAPIKeyRequest:
+      $ref: './schemas/apikey.yaml#/CreateAPIKeyRequest'
+    CreateAPIKeyResponse:
+      $ref: './schemas/apikey.yaml#/CreateAPIKeyResponse'
+    UpdateAPIKeyRequest:
+      $ref: './schemas/apikey.yaml#/UpdateAPIKeyRequest'

--- a/api/openapi/paths/apikey.yaml
+++ b/api/openapi/paths/apikey.yaml
@@ -1,0 +1,93 @@
+/api/api-keys:
+  get:
+    description: Get API keys for the current user with pagination
+    tags:
+      - APIKey
+    operationId: getAPIKeys
+    parameters:
+      - name: pageSize
+        in: query
+        required: true
+        description: Number of API keys per page (default 20, max 1000)
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 20
+      - name: pageIndex
+        in: query
+        required: true
+        description: Page index, starting from 1 (default 1)
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+    responses:
+      '200':
+        description: List of API keys
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/apikey.yaml#/APIKeysResponse'
+  post:
+    description: Create a new API key
+    tags:
+      - APIKey
+    operationId: createAPIKey
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/apikey.yaml#/CreateAPIKeyRequest"
+    responses:
+      '201':
+        description: API key created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/apikey.yaml#/CreateAPIKeyResponse'
+
+/api/api-keys/{id}:
+  patch:
+    description: Update an API key (enable/disable or modify properties)
+    tags:
+      - APIKey
+    operationId: updateAPIKey
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: API Key ID
+        schema:
+          type: integer
+          format: int64
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/apikey.yaml#/UpdateAPIKeyRequest"
+    responses:
+      '200':
+        description: API key updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/apikey.yaml#/APIKey'
+  delete:
+    description: Delete an API key
+    tags:
+      - APIKey
+    operationId: deleteAPIKey
+    parameters:
+      - name: id
+        in: path
+        required: true
+        description: API Key ID
+        schema:
+          type: integer
+          format: int64
+    responses:
+      '204':
+        description: API key deleted successfully

--- a/api/openapi/paths/audit.yaml
+++ b/api/openapi/paths/audit.yaml
@@ -1,0 +1,51 @@
+/api/audit-logs:
+  get:
+    description: Get audit logs with optional filtering and pagination
+    tags:
+      - Audit
+    operationId: getAuditLogs
+    parameters:
+      - name: startDate
+        in: query
+        required: false
+        description: Filter logs from this date (ISO 8601 format)
+        schema:
+          type: string
+          format: date-time
+      - name: endDate
+        in: query
+        required: false
+        description: Filter logs until this date (ISO 8601 format)
+        schema:
+          type: string
+          format: date-time
+      - name: vaultUniqueId
+        in: query
+        required: false
+        description: Filter logs by vault unique ID
+        schema:
+          type: string
+      - name: pageSize
+        in: query
+        required: true
+        description: Number of logs per page (default 100, max 1000)
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 1000
+          default: 20
+      - name: pageIndex
+        in: query
+        required: true
+        description: Page index, starting from 0 (default 0)
+        schema:
+          type: integer
+          minimum: 1
+          default: 1
+    responses:
+      '200':
+        description: List of audit logs
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/audit.yaml#/AuditLogsResponse'

--- a/api/openapi/paths/auth.yaml
+++ b/api/openapi/paths/auth.yaml
@@ -1,0 +1,49 @@
+/api/auth/login:
+  post:
+    description: Login with email and password
+    tags:
+      - Auth
+    operationId: login
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/auth.yaml#/LoginRequest"
+    responses:
+      '200':
+        description: Login successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/auth.yaml#/LoginResponse'
+
+/api/auth/signup:
+  post:
+    description: Sign up a new user
+    tags:
+      - Auth
+    operationId: signup
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/auth.yaml#/SignupRequest"
+    responses:
+      '200':
+        description: Sign up successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/auth.yaml#/SignupResponse'
+
+/api/auth/logout:
+  get:
+    description: Logout
+    tags:
+      - Auth
+    operationId: logout
+    responses:
+      '200':
+        description: OK

--- a/api/openapi/paths/health.yaml
+++ b/api/openapi/paths/health.yaml
@@ -1,0 +1,11 @@
+/api/health:
+  get:
+    description: Check the health status of backend
+    operationId: health
+    responses:
+      '200':
+        description: Service is healthy
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/health.yaml#/HealthCheckResponse'

--- a/api/openapi/paths/user.yaml
+++ b/api/openapi/paths/user.yaml
@@ -1,0 +1,13 @@
+/api/user:
+  get:
+    description: Get current user by credential
+    tags:
+      - User
+    operationId: getCurrentUser
+    responses:
+      '200':
+        description: User Info
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/user.yaml#/GetUserResponse'

--- a/api/openapi/paths/vault.yaml
+++ b/api/openapi/paths/vault.yaml
@@ -1,0 +1,94 @@
+/api/vaults:
+  get:
+    description: Get all vaults for the current user
+    tags:
+      - Vault
+    operationId: getVaults
+    responses:
+      '200':
+        description: List of vaults
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '../schemas/vault.yaml#/VaultLite'
+  post:
+    description: Create a new vault
+    tags:
+      - Vault
+    operationId: createVault
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/vault.yaml#/CreateVaultRequest"
+    responses:
+      '201':
+        description: Vault created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/vault.yaml#/Vault'
+
+/api/vaults/{uniqueId}:
+  get:
+    description: Get a specific vault by Unique ID
+    tags:
+      - Vault
+    operationId: getVault
+    parameters:
+      - name: uniqueId
+        in: path
+        required: true
+        description: Vault Unique ID
+        schema:
+          type: string
+    responses:
+      '200':
+        description: Vault details
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/vault.yaml#/Vault'
+  put:
+    description: Update a vault
+    tags:
+      - Vault
+    operationId: updateVault
+    parameters:
+      - name: uniqueId
+        in: path
+        required: true
+        description: Vault Unique ID
+        schema:
+          type: string
+    requestBody:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/vault.yaml#/UpdateVaultRequest"
+    responses:
+      '200':
+        description: Vault updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '../schemas/vault.yaml#/Vault'
+  delete:
+    description: Delete a vault
+    tags:
+      - Vault
+    operationId: deleteVault
+    parameters:
+      - name: uniqueId
+        in: path
+        required: true
+        description: Vault Unique ID
+        schema:
+          type: string
+    responses:
+      '204':
+        description: Vault deleted successfully

--- a/api/openapi/schemas/apikey.yaml
+++ b/api/openapi/schemas/apikey.yaml
@@ -1,0 +1,114 @@
+APIKeysResponse:
+  type: object
+  required:
+    - apiKeys
+    - totalCount
+    - pageSize
+    - pageIndex
+  properties:
+    apiKeys:
+      type: array
+      items:
+        $ref: '#/APIKey'
+    totalCount:
+      type: integer
+      description: Total number of API keys
+    pageSize:
+      type: integer
+      description: Number of API keys per page
+    pageIndex:
+      type: integer
+      description: Current page index (starting from 1)
+
+APIKey:
+  type: object
+  required:
+    - id
+    - name
+    - isActive
+    - createdAt
+  properties:
+    id:
+      type: integer
+      format: int64
+      description: Unique API key ID
+    name:
+      type: string
+      description: Human-readable name for the API key
+    vaults:
+      type: array
+      items:
+        $ref: 'vault.yaml#/VaultLite'
+      description: Array of vaults this key can access (null/empty = all user's vaults)
+    expiresAt:
+      type: string
+      format: date-time
+      description: Optional expiration date
+    lastUsedAt:
+      type: string
+      format: date-time
+      description: When the key was last used
+    isActive:
+      type: boolean
+      description: Whether the key is currently active
+    createdAt:
+      type: string
+      format: date-time
+      description: When the key was created
+    updatedAt:
+      type: string
+      format: date-time
+      description: When the key was last updated
+
+CreateAPIKeyRequest:
+  type: object
+  required:
+    - name
+  properties:
+    name:
+      type: string
+      description: Human-readable name for the API key
+      minLength: 1
+      maxLength: 255
+    vaultUniqueIds:
+      type: array
+      items:
+        type: string
+      description: Array of vault unique IDs this key can access (empty = all user's vaults)
+    expiresAt:
+      type: string
+      format: date-time
+      description: Optional expiration date
+
+CreateAPIKeyResponse:
+  type: object
+  required:
+    - apiKey
+    - key
+  properties:
+    apiKey:
+      $ref: '#/APIKey'
+    key:
+      type: string
+      description: The generated API key (only shown once)
+
+UpdateAPIKeyRequest:
+  type: object
+  properties:
+    name:
+      type: string
+      description: Human-readable name for the API key
+      minLength: 1
+      maxLength: 255
+    vaultUniqueIds:
+      type: array
+      items:
+        type: string
+      description: Array of vault unique IDs this key can access (empty = all user's vaults)
+    expiresAt:
+      type: string
+      format: date-time
+      description: Optional expiration date
+    isActive:
+      type: boolean
+      description: Enable or disable the API key

--- a/api/openapi/schemas/audit.yaml
+++ b/api/openapi/schemas/audit.yaml
@@ -1,0 +1,47 @@
+AuditLogsResponse:
+  type: object
+  required:
+    - auditLogs
+    - totalCount
+    - pageSize
+    - pageIndex
+  properties:
+    auditLogs:
+      type: array
+      items:
+        $ref: '#/AuditLog'
+    totalCount:
+      type: integer
+      description: Total number of logs matching the filter criteria
+    pageSize:
+      type: integer
+      description: Number of logs per page
+    pageIndex:
+      type: integer
+      description: Current page index (starting from 0)
+
+AuditLog:
+  type: object
+  required:
+    - createdAt
+    - userId
+    - action
+  properties:
+    createdAt:
+      type: string
+      format: date-time
+      description: When the action occurred
+    vault:
+      $ref: 'vault.yaml#/VaultLite'
+    apiKey:
+      $ref: 'apikey.yaml#/APIKey'
+    action:
+      type: string
+      enum: [read_vault, update_vault, delete_vault, create_vault, login_user, register_user, logout_user, create_api_key, update_api_key, delete_api_key]
+      description: Type of action performed
+    ipAddress:
+      type: string
+      description: IP address from which the action was performed
+    userAgent:
+      type: string
+      description: User agent string from the client

--- a/api/openapi/schemas/auth.yaml
+++ b/api/openapi/schemas/auth.yaml
@@ -1,0 +1,42 @@
+LoginRequest:
+  type: object
+  required:
+    - email
+    - password
+  properties:
+    email:
+      type: string
+      format: email
+    password:
+      type: string
+
+LoginResponse:
+  type: object
+  required:
+    - token
+  properties:
+    token:
+      type: string
+
+SignupRequest:
+  type: object
+  required:
+    - email
+    - password
+    - name
+  properties:
+    email:
+      type: string
+      format: email
+    password:
+      type: string
+    name:
+      type: string
+
+SignupResponse:
+  type: object
+  required:
+    - token
+  properties:
+    token:
+      type: string

--- a/api/openapi/schemas/health.yaml
+++ b/api/openapi/schemas/health.yaml
@@ -1,0 +1,10 @@
+HealthCheckResponse:
+  type: object
+  properties:
+    status:
+      type: string
+      example: "ok"
+    timestamp:
+      type: string
+      format: date-time
+      example: "2023-10-11T12:34:56Z"

--- a/api/openapi/schemas/user.yaml
+++ b/api/openapi/schemas/user.yaml
@@ -1,0 +1,12 @@
+GetUserResponse:
+  type: object
+  required:
+    - email
+  properties:
+    email:
+      type: string
+      format: email
+    name:
+      type: string
+    avatar:
+      type: string

--- a/api/openapi/schemas/vault.yaml
+++ b/api/openapi/schemas/vault.yaml
@@ -1,0 +1,99 @@
+VaultLite:
+  type: object
+  required:
+    - uniqueId
+    - name
+  properties:
+    uniqueId:
+      type: string
+      description: Unique identifier for the vault
+    name:
+      type: string
+      description: Human-readable name
+    description:
+      type: string
+      description: Human-readable description
+    category:
+      type: string
+      description: Category/type of vault
+    updatedAt:
+      type: string
+      format: date-time
+
+Vault:
+  type: object
+  required:
+    - uniqueId
+    - name
+    - value
+  properties:
+    uniqueId:
+      type: string
+      description: Unique identifier for the vault
+    userId:
+      type: integer
+      format: int64
+      description: ID of the user who owns this vault
+    name:
+      type: string
+      description: Human-readable name
+    value:
+      type: string
+      description: Encrypted value
+    description:
+      type: string
+      description: Human-readable description
+    category:
+      type: string
+      description: Category/type of vault
+    createdAt:
+      type: string
+      format: date-time
+    updatedAt:
+      type: string
+      format: date-time
+
+CreateVaultRequest:
+  type: object
+  required:
+    - name
+    - value
+  properties:
+    name:
+      type: string
+      description: Human-readable name
+      minLength: 1
+      maxLength: 255
+    value:
+      type: string
+      description: Value to be encrypted and stored
+      minLength: 1
+    description:
+      type: string
+      description: Human-readable description
+      maxLength: 500
+    category:
+      type: string
+      description: Category/type of vault
+      maxLength: 100
+
+UpdateVaultRequest:
+  type: object
+  properties:
+    name:
+      type: string
+      description: Human-readable name
+      minLength: 1
+      maxLength: 255
+    value:
+      type: string
+      description: Value to be encrypted and stored
+      minLength: 1
+    description:
+      type: string
+      description: Human-readable description
+      maxLength: 500
+    category:
+      type: string
+      description: Category/type of vault
+      maxLength: 100

--- a/api/tool.go
+++ b/api/tool.go
@@ -1,3 +1,3 @@
 package api
 
-//go:generate go tool oapi-codegen -config cfg.yaml api.yaml
+//go:generate sh -c "redocly bundle openapi/main.yaml -o api.yaml --force && go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen -config cfg.yaml api.yaml"


### PR DESCRIPTION
Splits the monolithic `api/api.yaml` into modular files and updates `go generate` to bundle them, enhancing API specification organization and maintainability.

---
<a href="https://cursor.com/background-agent?bcId=bc-02904768-7697-432f-84f4-ae0d75cffe3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-02904768-7697-432f-84f4-ae0d75cffe3a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Split the monolithic OpenAPI specification into modular schema and path files under api/openapi and update the code generation process to bundle and generate the API definitions.

Enhancements:
- Organize API spec into separate YAML modules under api/openapi for schemas and paths
- Add api/openapi/main.yaml as the entry point that references all modular components
- Remove inline component definitions from the original api/api.yaml

Build:
- Update go:generate in api/tool.go to bundle the modular spec with Redocly and invoke oapi-codegen to regenerate api.yaml