### PR TITLE
chore(workflows): add allowed_bots parameter to Claude workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,8 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
+          # Comma-separated list of allowed bot usernames, or '*' to allow all bots. Empty string (default) allows no bots.
+          allowed_bots: "cursor,dependabot"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,8 @@ jobs:
         env:
           ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
+          # Comma-separated list of allowed bot usernames, or '*' to allow all bots. Empty string (default) allows no bots.
+          allowed_bots: "cursor,dependabot"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
 
           # This is an optional setting that allows Claude to read CI results on PRs


### PR DESCRIPTION
Added a new parameter 'allowed_bots' to the Claude workflows, specifying a comma-separated list of allowed bot usernames (cursor, dependabot) to enhance bot management during CI processes.

## Summary by Sourcery

CI:
- Add allowed_bots input to claude and claude-code-review workflows to specify a comma-separated list of permitted bot usernames.