### PR TITLE
feat: add GitHub Actions workflow for building and publishing Go client

### DIFF
--- a/.github/workflows/publish-go-client.yml
+++ b/.github/workflows/publish-go-client.yml
@@ -4,8 +4,6 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
 
 jobs:
   build-and-publish:
@@ -37,7 +35,6 @@ jobs:
         run: |
           cd go-client
           go mod tidy
-          go build ./...
           
           # Create repository if it doesn't exist and push
           git config --global user.name "github-actions[bot]"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -86,4 +86,3 @@ build-openapi-go-client:
     # Initialize Go module
     - cd go-client
     - go mod tidy
-    - go build ./...


### PR DESCRIPTION
## Summary by Sourcery

Add Go client generation and publishing pipelines by enhancing GitLab CI and introducing a GitHub Actions workflow

New Features:
- Add a build-openapi-go-client job in GitLab CI to generate and tidy the Go client from the OpenAPI spec
- Introduce a GitHub Actions workflow to build, tag, and publish the Go client library to a dedicated repository

Enhancements:
- Rename existing build-openapi-client job in GitLab CI to build-openapi-typescript-client