### PR TITLE
Implement vault hub cli with config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/golang-jwt/jwt/v5 v5.3.0
 	github.com/google/uuid v1.6.0
 	github.com/joho/godotenv v1.5.1
+	github.com/lwshen/vault-hub-go-client v0.20250818.162321
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/orandin/slog-gorm v1.4.0
 	github.com/samber/slog-fiber v1.18.0
@@ -21,6 +22,8 @@ require (
 	gorm.io/driver/sqlite v1.6.0
 	gorm.io/gorm v1.30.1
 )
+
+replace github.com/lwshen/vault-hub-go-client => ./lib/vault-hub-go-client
 
 require (
 	filippo.io/edwards25519 v1.1.0 // indirect

--- a/lib/vault-hub-go-client/client.go
+++ b/lib/vault-hub-go-client/client.go
@@ -1,0 +1,108 @@
+package vhub
+
+import (
+    "context"
+    "encoding/json"
+    "fmt"
+    "net/http"
+    "time"
+)
+
+// Client is a lightweight Vault Hub API client focused on CLI use-cases.
+// It supports listing vaults and retrieving single vaults by unique ID or name.
+type Client struct {
+    BaseURL    string
+    APIKey     string
+    HTTPClient *http.Client
+}
+
+// NewClient constructs a new Client. If httpClient is nil, http.DefaultClient is used.
+func NewClient(baseURL, apiKey string) *Client {
+    return &Client{
+        BaseURL:    baseURL,
+        APIKey:     apiKey,
+        HTTPClient: http.DefaultClient,
+    }
+}
+
+// VaultLite mirrors the server's lightweight vault representation.
+// Only the fields needed by the CLI are included.
+// Timestamps are parsed as RFC3339.
+//
+// NOTE: Keep in sync with server API surface.
+type VaultLite struct {
+    Name        string     `json:"name"`
+    UniqueId    string     `json:"uniqueId"`
+    Category    *string    `json:"category,omitempty"`
+    Description *string    `json:"description,omitempty"`
+    UpdatedAt   *time.Time `json:"updatedAt,omitempty"`
+}
+
+// Vault represents the full vault resource returned by the API.
+// It embeds VaultLite and adds the encrypted value and creation metadata.
+type Vault struct {
+    VaultLite
+    Value     string     `json:"value"`
+    CreatedAt *time.Time `json:"createdAt,omitempty"`
+    UserId    *int64     `json:"userId,omitempty"`
+}
+
+// ListVaults returns all vaults accessible with the API key.
+func (c *Client) ListVaults(ctx context.Context) ([]VaultLite, error) {
+    var vaults []VaultLite
+    if err := c.doRequest(ctx, http.MethodGet, "/api/cli/vaults", nil, &vaults); err != nil {
+        return nil, err
+    }
+    return vaults, nil
+}
+
+// GetVault fetches a vault by its unique ID.
+func (c *Client) GetVault(ctx context.Context, uniqueId string) (*Vault, error) {
+    var v Vault
+    path := fmt.Sprintf("/api/cli/vault/%s", uniqueId)
+    if err := c.doRequest(ctx, http.MethodGet, path, nil, &v); err != nil {
+        return nil, err
+    }
+    return &v, nil
+}
+
+// GetVaultByName fetches a vault by its name.
+func (c *Client) GetVaultByName(ctx context.Context, name string) (*Vault, error) {
+    var v Vault
+    path := fmt.Sprintf("/api/cli/vault/name/%s", name)
+    if err := c.doRequest(ctx, http.MethodGet, path, nil, &v); err != nil {
+        return nil, err
+    }
+    return &v, nil
+}
+
+// doRequest performs the HTTP request and decodes the JSON response into dest if provided.
+func (c *Client) doRequest(ctx context.Context, method, path string, body any, dest any) error {
+    req, err := http.NewRequestWithContext(ctx, method, c.BaseURL+path, nil)
+    if err != nil {
+        return err
+    }
+    req.Header.Set("Accept", "application/json")
+    if c.APIKey != "" {
+        req.Header.Set("X-API-Key", c.APIKey)
+    }
+
+    resp, err := c.HTTPClient.Do(req)
+    if err != nil {
+        return err
+    }
+    defer resp.Body.Close()
+
+    if resp.StatusCode >= 300 {
+        return fmt.Errorf("request failed: %s", resp.Status)
+    }
+
+    if dest != nil {
+        decoder := json.NewDecoder(resp.Body)
+        if err := decoder.Decode(dest); err != nil {
+            return fmt.Errorf("failed to decode response: %w", err)
+        }
+    }
+
+    return nil
+}

--- a/lib/vault-hub-go-client/go.mod
+++ b/lib/vault-hub-go-client/go.mod
@@ -1,0 +1,3 @@
+module github.com/lwshen/vault-hub-go-client
+
+go 1.24.2


### PR DESCRIPTION
Implement VaultHub CLI for listing and retrieving vaults with API key and base URL configuration.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3142596-bb7d-4b10-aea2-e3607d513a41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3142596-bb7d-4b10-aea2-e3607d513a41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Implement VaultHub CLI with configurable API key and base URL and add supporting Go client library

New Features:
- Add 'list' command to fetch and display vaults as a table
- Add 'get' command to retrieve and pretty-print individual vaults by name or ID
- Support API key and base URL configuration via flags or environment variables

Enhancements:
- Introduce buildClient helper for initializing the API client
- Format vault lists in table style and vault details in JSON output

Build:
- Add vault-hub-go-client dependency to go.mod with local replace directive