### PR TITLE
Fix license generation and enable PR runs

### DIFF
--- a/.github/workflows/publish-go-client.yml
+++ b/.github/workflows/publish-go-client.yml
@@ -4,6 +4,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   build-and-publish:
@@ -30,6 +32,10 @@ jobs:
           openapi-file: packages/api/openapi/api.yaml
           generator-tag: v7.13.0
           command-args: --additional-properties=packageVersion=${{ env.TAG }} --additional-properties=moduleName=github.com/lwshen/vault-hub-go-client --git-user-id lwshen --git-repo-id vault-hub-go-client
+
+      - name: Copy LICENSE file
+        run: |
+          cp LICENSE go-client/LICENSE
 
       - name: Initialize Go module and publish
         run: |


### PR DESCRIPTION
Add LICENSE file to generated Go client and temporarily enable workflow on pull requests.

---
<a href="https://cursor.com/background-agent?bcId=bc-703022fc-8860-4ccc-83c3-77a80006603d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-703022fc-8860-4ccc-83c3-77a80006603d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Enable publish-go-client workflow on pull requests and ensure the generated Go client includes the project LICENSE

Bug Fixes:
- Copy root LICENSE file into the generated Go client directory to include the license in the output

CI:
- Allow publish-go-client workflow to run on pull_request events for the main branch