### PR TITLE
ci: ensure git history in publish go client workflow

### DIFF
--- a/.github/workflows/publish-go-client.yml
+++ b/.github/workflows/publish-go-client.yml
@@ -30,22 +30,40 @@ jobs:
         run: cp LICENSE go-client/LICENSE
       - name: Initialize Go module and publish
         run: |
+          # Prepare generated client
           cd go-client
           go mod tidy
+          cd ..
 
-          # Create repository if it doesn't exist and push
+          # Configure git identity
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-          git init -b main
-          git add .
-          git commit -m "Generated Go client library ${{ env.TAG }}"
+          # Clone existing repository to preserve history
+          git clone https://${{ secrets.PUBLISH_TOKEN }}@github.com/lwshen/vault-hub-go-client.git publish-repo
+          cd publish-repo
+
+          # Ensure we are on main (create if missing)
+          git checkout -B main || git checkout -b main
+
+          # Replace repository contents (except .git) with newly generated client
+          find . -mindepth 1 -maxdepth 1 ! -name ".git" -exec rm -rf {} +
+          cp -R ../go-client/. .
+
+          # Commit changes only if there are modifications
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Generated Go client library ${{ env.TAG }}"
+          fi
+
+          # Tag the release
           git tag ${{ env.TAG }}
 
           # Push to separate repository only outside of pull_request events
           if [ "${{ github.event_name }}" != "pull_request" ]; then
-            git remote add origin https://${{ secrets.PUBLISH_TOKEN }}@github.com/lwshen/vault-hub-go-client.git
-            git push -f origin main
+            git push origin main
             git push origin ${{ env.TAG }}
           else
             echo "Skipping push during pull_request event"


### PR DESCRIPTION
Update `publish-go-client.yml` to preserve Git history when publishing the Go client library.

---
<a href="https://cursor.com/background-agent?bcId=bc-bea9246b-95fc-451b-a349-44fdebc4e51b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bea9246b-95fc-451b-a349-44fdebc4e51b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

## Summary by Sourcery

Update the Go client publishing workflow to preserve Git history by cloning the existing repository, replacing its contents, and committing and tagging changes only when needed before pushing.

CI:
- Configure Git identity and clone the existing vault-hub-go-client repository instead of reinitializing to retain commit history
- Checkout or create the main branch, replace all files except .git with the newly generated client, and commit only if there are modifications
- Tag the release and push updates normally without force pushing, while continuing to skip pushes during pull request events