### PR TITLE
ci: correct version tagging format in Go client publish workflow

### DIFF
--- a/.github/workflows/publish-go-client.yml
+++ b/.github/workflows/publish-go-client.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           go-version: "1.21"
       - name: Set env
-        run: echo "TAG=v0.$(date +'%Y%m%d.%H%M%S')" >> "$GITHUB_ENV"
+        run: echo "TAG=v0.0.$(date +'%Y%m%d%H%M%S')" >> "$GITHUB_ENV"
       - name: Generate Go Client Library
         uses: openapi-generators/openapitools-generator-action@v1
         with:


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update TAG environment variable to use v0.0.<timestamp> instead of v0.<timestamp>