### PR TITLE
ci: add release workflow

### DIFF
--- a/.github/changelog_configuration.json
+++ b/.github/changelog_configuration.json
@@ -1,0 +1,59 @@
+{
+  "categories": [
+    {
+      "title": "## 🚀 Features",
+      "labels": ["enhancement", "feature", "feat"]
+    },
+    {
+      "title": "## 🐛 Bug Fixes",
+      "labels": ["bug", "fix", "bugfix"]
+    },
+    {
+      "title": "## 📚 Documentation",
+      "labels": ["documentation", "docs"]
+    },
+    {
+      "title": "## 🔧 Maintenance", 
+      "labels": ["maintenance", "chore", "refactor"]
+    },
+    {
+      "title": "## ⚡ Performance",
+      "labels": ["performance", "perf"]
+    },
+    {
+      "title": "## 🔒 Security",
+      "labels": ["security"]
+    },
+    {
+      "title": "## 💥 Breaking Changes",
+      "labels": ["breaking-change", "breaking"]
+    }
+  ],
+  "ignore_labels": [
+    "ignore-for-release"
+  ],
+  "sort": "ASC",
+  "template": "${{CHANGELOG}}",
+  "pr_template": "- ${{TITLE}} by @${{AUTHOR}} in #${{NUMBER}}",
+  "empty_template": "- No changes",
+  "label_extractor": [
+    {
+      "pattern": "feat\\((.+)\\):",
+      "target": "$1",
+      "flags": "gu"
+    },
+    {
+      "pattern": "fix\\((.+)\\):",
+      "target": "$1", 
+      "flags": "gu"
+    }
+  ],
+  "duplicate_filter": {
+    "pattern": "\\[.*\\]",
+    "on_property": "title",
+    "method": "match"
+  },
+  "max_tags_to_fetch": 200,
+  "max_pull_requests": 1000,
+  "max_back_track_time_days": 1000
+}

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -43,11 +43,10 @@ jobs:
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
-# Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
-# model: "claude-opus-4-20250514"
-# Optional: Customize the trigger phrase (default: @claude)
-# trigger_phrase: "/claude"
-
+          # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
+          # model: "claude-opus-4-20250514"
+          # Optional: Customize the trigger phrase (default: @claude)
+          # trigger_phrase: "/claude"
 # Optional: Trigger when specific user is assigned to an issue
 # assignee_trigger: "claude-bot"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,105 @@ on:
 permissions:
   contents: write
   pull-requests: read
+  packages: write
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: ./apps/web/package.json
+          run_install: false
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: pnpm
+          cache-dependency-path: ./apps/web/pnpm-lock.yaml
+      - name: Install frontend dependencies
+        working-directory: ./apps/web
+        run: pnpm install
+      - name: Build frontend
+        working-directory: ./apps/web
+        run: pnpm build
+      - name: Build Server Binaries
+        run: |
+          # Linux builds
+          GOOS=linux GOARCH=amd64 go build -o bin/vault-hub-server-linux-amd64 apps/server/main.go
+          GOOS=linux GOARCH=arm64 go build -o bin/vault-hub-server-linux-arm64 apps/server/main.go
+
+          # Windows builds
+          GOOS=windows GOARCH=amd64 go build -o bin/vault-hub-server-windows-amd64.exe apps/server/main.go
+
+          # macOS builds
+          GOOS=darwin GOARCH=amd64 go build -o bin/vault-hub-server-darwin-amd64 apps/server/main.go
+          GOOS=darwin GOARCH=arm64 go build -o bin/vault-hub-server-darwin-arm64 apps/server/main.go
+      - name: Build CLI Binaries
+        run: |
+          # Linux builds
+          GOOS=linux GOARCH=amd64 go build -o bin/vault-hub-cli-linux-amd64 apps/cli/main.go
+          GOOS=linux GOARCH=arm64 go build -o bin/vault-hub-cli-linux-arm64 apps/cli/main.go
+
+          # Windows builds
+          GOOS=windows GOARCH=amd64 go build -o bin/vault-hub-cli-windows-amd64.exe apps/cli/main.go
+
+          # macOS builds
+          GOOS=darwin GOARCH=amd64 go build -o bin/vault-hub-cli-darwin-amd64 apps/cli/main.go
+          GOOS=darwin GOARCH=arm64 go build -o bin/vault-hub-cli-darwin-arm64 apps/cli/main.go
+      - name: Upload Release Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            bin/vault-hub-server-*
+            bin/vault-hub-cli-*
+  docker:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/lwshen/vault-hub
+          tags: |
+            type=ref,event=tag
+            type=raw,value=latest
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   changelog:
     runs-on: ubuntu-latest
+    needs:
+      - build
+      - docker
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+on:
+  release:
+    types:
+      - created
+permissions:
+  contents: write
+  pull-requests: read
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Build Changelog
+        id: github_release
+        uses: mikepenz/release-changelog-builder-action@v5
+        with:
+          configuration: .github/changelog_configuration.json
+          outputFile: CHANGELOG.md
+          commitMode: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit Changelog
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: 'docs: update CHANGELOG.md for ${{ github.event.release.tag_name }}'
+          file_pattern: CHANGELOG.md


### PR DESCRIPTION
## Summary by Sourcery

Add a GitHub Actions release workflow triggered on new releases to build and publish all assets and update the changelog

CI:
- Trigger a release pipeline on GitHub release creation
- Build front-end assets and Go server/CLI binaries for multiple OS and architectures
- Upload compiled binaries as GitHub release assets
- Build and push a multi-platform Docker image to GitHub Container Registry
- Generate and commit the updated CHANGELOG.md automatically

Chores:
- Adjust indentation and formatting in the existing Claude workflow configuration