### PR TITLE
ci: update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,36 +116,72 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-      - name: Generate TypeScript Client
+      - name: Generate TypeScript Fetch Client Library
+        uses: openapi-generators/openapitools-generator-action@v1
+        with:
+          generator: typescript-fetch
+          openapi-file: packages/api/openapi/api.yaml
+          generator-tag: v7.13.0
+          command-args: --additional-properties=npmName=@lwshen/vault-hub-ts-fetch-client --additional-properties=npmVersion=${{ github.ref_name }} --additional-properties=useSingleRequestParameter=false --git-user-id lwshen --git-repo-id vault-hub
+      - name: Build TypeScript Client
         run: |
-          npx @openapitools/openapi-generator-cli generate \
-            -i packages/api/openapi/api.yaml \
-            -g typescript-fetch \
-            -o typescript-client \
-            --additional-properties=npmName=@lwshen/vault-hub-ts-fetch-client,npmVersion=${{ github.ref_name }},supportsES6=true
+          cd typescript-fetch-client
+          npm install
+          npm run build
       - name: Publish TypeScript Client
-        working-directory: ./typescript-client
         run: |
-          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          cd typescript-fetch-client
           npm publish --access public
-      - name: Generate Go Client
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Generate Go Client Library
+        uses: openapi-generators/openapitools-generator-action@v1
+        with:
+          generator: go
+          openapi-file: packages/api/openapi/api.yaml
+          generator-tag: v7.13.0
+          command-args: --additional-properties=packageVersion=${{ github.ref_name }} --additional-properties=moduleName=github.com/lwshen/vault-hub-go-client --git-user-id lwshen --git-repo-id vault-hub-go-client
+      - name: Ensure LICENSE is included
+        run: cp LICENSE go-client/LICENSE
+      - name: Initialize Go module and publish
         run: |
-          mkdir -p go-client
-          go install github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@latest
-          oapi-codegen -package vaultclient -generate types,client packages/api/openapi/api.yaml > go-client/client.go
-      - name: Publish Go Client
-        working-directory: ./go-client
-        run: |
-          go mod init github.com/lwshen/vault-hub-go-client
+          # Prepare generated client
+          cd go-client
           go mod tidy
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-          git init
-          git add .
-          git commit -m "Release ${{ github.ref_name }}"
+          go build ./...
+
+          # Create repository if it doesn't exist and push
+          cd ..
+
+          # Configure git identity
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Clone existing repository to preserve history
+          git clone https://${{ secrets.PUBLISH_TOKEN }}@github.com/lwshen/vault-hub-go-client.git publish-repo
+          cd publish-repo
+
+          # Ensure we are on main (create if missing)
+          git checkout -B main || git checkout -b main
+
+          # Replace repository contents (except .git) with newly generated client
+          find . -mindepth 1 -maxdepth 1 ! -name ".git" -exec rm -rf {} +
+          cp -R ../go-client/. .
+
+          # Commit changes only if there are modifications
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Release ${{ github.ref_name }}"
+          fi
+
+          # Tag the release
           git tag ${{ github.ref_name }}
-          git remote add origin https://${{ secrets.GITHUB_TOKEN }}@github.com/lwshen/vault-hub-go-client.git
-          git push origin main --tags || git push -u origin main --tags
+
+          # Push to separate repository
+          git push origin main
+          git push origin ${{ github.ref_name }}
   changelog:
     runs-on: ubuntu-latest
     needs:
@@ -157,7 +193,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Build Changelog
-        id: github_release
+        id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v5
         with:
           mode: COMMIT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 on:
-  release:
-    types:
-      - created
+  push:
+    # run only against tags
+    tags:
+      - v*
 permissions:
   contents: write
   pull-requests: read
@@ -63,6 +64,7 @@ jobs:
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2
         with:
+          name: v${{ github.ref_name }}
           files: |
             bin/vault-hub-server-*
             bin/vault-hub-cli-*
@@ -100,11 +102,56 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+  publish-clients:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v5
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.24"
+          cache: true
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Generate TypeScript Client
+        run: |
+          npx @openapitools/openapi-generator-cli generate \
+            -i packages/api/openapi/api.yaml \
+            -g typescript-fetch \
+            -o typescript-client \
+            --additional-properties=npmName=@lwshen/vault-hub-ts-fetch-client,npmVersion=${{ github.ref_name }},supportsES6=true
+      - name: Publish TypeScript Client
+        working-directory: ./typescript-client
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > .npmrc
+          npm publish --access public
+      - name: Generate Go Client
+        run: |
+          mkdir -p go-client
+          go install github.com/deepmap/oapi-codegen/v2/cmd/oapi-codegen@latest
+          oapi-codegen -package vaultclient -generate types,client packages/api/openapi/api.yaml > go-client/client.go
+      - name: Publish Go Client
+        working-directory: ./go-client
+        run: |
+          go mod init github.com/lwshen/vault-hub-go-client
+          go mod tidy
+          git config --global user.name "GitHub Actions"
+          git config --global user.email "actions@github.com"
+          git init
+          git add .
+          git commit -m "Release ${{ github.ref_name }}"
+          git tag ${{ github.ref_name }}
+          git remote add origin https://${{ secrets.GITHUB_TOKEN }}@github.com/lwshen/vault-hub-go-client.git
+          git push origin main --tags || git push -u origin main --tags
   changelog:
     runs-on: ubuntu-latest
     needs:
       - build
       - docker
+      - publish-clients
     steps:
       - uses: actions/checkout@v5
         with:
@@ -113,13 +160,13 @@ jobs:
         id: github_release
         uses: mikepenz/release-changelog-builder-action@v5
         with:
+          mode: COMMIT
           configuration: .github/changelog_configuration.json
           outputFile: CHANGELOG.md
-          commitMode: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Commit Changelog
-        uses: stefanzweifel/git-auto-commit-action@v5
+      - name: Release
+        uses: softprops/action-gh-release@v2
         with:
-          commit_message: 'docs: update CHANGELOG.md for ${{ github.event.release.tag_name }}'
-          file_pattern: CHANGELOG.md
+          name: v${{ github.ref_name }}
+          body: ${{steps.build_changelog.outputs.changelog}}


### PR DESCRIPTION
- Changed the trigger from release creation to tag pushes for better version control.
- Added a new job to publish TypeScript and Go clients after the build process.
- Enhanced the release asset upload step to include versioning based on the tag name.
- Updated changelog generation to reflect the new release process.

## Summary by Sourcery

Update the release workflow to trigger on tag pushes, include versioned release assets, automate changelog updates, and add client publishing steps

New Features:
- Add a CI job to generate and publish TypeScript and Go clients after the build

Enhancements:
- Trigger releases on tag pushes matching v* instead of release events
- Include the tag-derived version name when uploading release assets
- Switch changelog generation to COMMIT mode and integrate it into the GitHub Release
- Remove separate changelog commit step and use the release action to publish the changelog