### PR TITLE
ci: fix release workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
           COMMIT=$(git rev-parse --short HEAD)
           LDFLAGS="-X github.com/lwshen/vault-hub/internal/version.Version=${VERSION} -X github.com/lwshen/vault-hub/internal/version.Commit=${COMMIT}"
-          
+
           # Linux builds
           GOOS=linux GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-linux-amd64 apps/server/main.go
           GOOS=linux GOARCH=arm64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-linux-arm64 apps/server/main.go
@@ -73,7 +73,7 @@ jobs:
           VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "dev")
           COMMIT=$(git rev-parse --short HEAD)
           LDFLAGS="-X github.com/lwshen/vault-hub/internal/version.Version=${VERSION} -X github.com/lwshen/vault-hub/internal/version.Commit=${COMMIT}"
-          
+
           # Linux builds
           GOOS=linux GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-linux-amd64 apps/cli/main.go
           GOOS=linux GOARCH=arm64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-linux-arm64 apps/cli/main.go

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,18 +42,18 @@ jobs:
           VERSION=${{ github.ref_name }}
           COMMIT=$(git rev-parse --short HEAD)
           LDFLAGS="-X github.com/lwshen/vault-hub/internal/version.Version=${VERSION} -X github.com/lwshen/vault-hub/internal/version.Commit=${COMMIT}"
-          
+
           echo "Building server binaries with version: $VERSION, commit: $COMMIT"
           echo "LDFLAGS: $LDFLAGS"
-          
+
           # Create bin directory if it doesn't exist
           mkdir -p bin
-          
+
           # Linux builds
           echo "Building Linux AMD64..."
           GOOS=linux GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-linux-amd64 apps/server/main.go
           echo "✓ Built vault-hub-server-linux-amd64"
-          
+
           echo "Building Linux ARM64..."
           GOOS=linux GOARCH=arm64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-linux-arm64 apps/server/main.go
           echo "✓ Built vault-hub-server-linux-arm64"
@@ -67,11 +67,11 @@ jobs:
           echo "Building macOS AMD64..."
           GOOS=darwin GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-darwin-amd64 apps/server/main.go
           echo "✓ Built vault-hub-server-darwin-amd64"
-          
+
           echo "Building macOS ARM64..."
           GOOS=darwin GOARCH=arm64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-darwin-arm64 apps/server/main.go
           echo "✓ Built vault-hub-server-darwin-arm64"
-          
+
           echo "All server binaries built successfully!"
           echo "Listing built files:"
           ls -la bin/vault-hub-server-*
@@ -80,18 +80,18 @@ jobs:
           VERSION=${{ github.ref_name }}
           COMMIT=$(git rev-parse --short HEAD)
           LDFLAGS="-X github.com/lwshen/vault-hub/internal/version.Version=${VERSION} -X github.com/lwshen/vault-hub/internal/version.Commit=${COMMIT}"
-          
+
           echo "Building CLI binaries with version: $VERSION, commit: $COMMIT"
           echo "LDFLAGS: $LDFLAGS"
-          
+
           # Create bin directory if it doesn't exist
           mkdir -p bin
-          
+
           # Linux builds
           echo "Building CLI Linux AMD64..."
           GOOS=linux GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-linux-amd64 apps/cli/main.go
           echo "✓ Built vault-hub-cli-linux-amd64"
-          
+
           echo "Building CLI Linux ARM64..."
           GOOS=linux GOARCH=arm64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-linux-arm64 apps/cli/main.go
           echo "✓ Built vault-hub-cli-linux-arm64"
@@ -105,11 +105,11 @@ jobs:
           echo "Building CLI macOS AMD64..."
           GOOS=darwin GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-darwin-amd64 apps/cli/main.go
           echo "✓ Built vault-hub-cli-darwin-amd64"
-          
+
           echo "Building CLI macOS ARM64..."
           GOOS=darwin GOARCH=arm64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-darwin-arm64 apps/cli/main.go
           echo "✓ Built vault-hub-cli-darwin-arm64"
-          
+
           echo "All CLI binaries built successfully!"
           echo "Listing built files:"
           ls -la bin/vault-hub-cli-*
@@ -272,11 +272,11 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          
+
           # Switch to main branch (we're in detached HEAD from tag checkout)
           git checkout main
           git pull origin main
-          
+
           # Add and commit changelog if there are changes
           git add CHANGELOG.md
           if ! git diff --staged --quiet; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,9 +272,19 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+          
+          # Switch to main branch (we're in detached HEAD from tag checkout)
+          git checkout main
+          git pull origin main
+          
+          # Add and commit changelog if there are changes
           git add CHANGELOG.md
-          git diff --staged --quiet || git commit -m "chore: update CHANGELOG.md for ${{ github.ref_name }}"
-          git push
+          if ! git diff --staged --quiet; then
+            git commit -m "chore: update CHANGELOG.md for ${{ github.ref_name }}"
+            git push origin main
+          else
+            echo "No changes to CHANGELOG.md, skipping commit"
+          fi
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,32 +43,76 @@ jobs:
           COMMIT=$(git rev-parse --short HEAD)
           LDFLAGS="-X github.com/lwshen/vault-hub/internal/version.Version=${VERSION} -X github.com/lwshen/vault-hub/internal/version.Commit=${COMMIT}"
           
+          echo "Building server binaries with version: $VERSION, commit: $COMMIT"
+          echo "LDFLAGS: $LDFLAGS"
+          
+          # Create bin directory if it doesn't exist
+          mkdir -p bin
+          
           # Linux builds
+          echo "Building Linux AMD64..."
           GOOS=linux GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-linux-amd64 apps/server/main.go
+          echo "✓ Built vault-hub-server-linux-amd64"
+          
+          echo "Building Linux ARM64..."
           GOOS=linux GOARCH=arm64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-linux-arm64 apps/server/main.go
+          echo "✓ Built vault-hub-server-linux-arm64"
 
           # Windows builds
+          echo "Building Windows AMD64..."
           GOOS=windows GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-windows-amd64.exe apps/server/main.go
+          echo "✓ Built vault-hub-server-windows-amd64.exe"
 
           # macOS builds
+          echo "Building macOS AMD64..."
           GOOS=darwin GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-darwin-amd64 apps/server/main.go
+          echo "✓ Built vault-hub-server-darwin-amd64"
+          
+          echo "Building macOS ARM64..."
           GOOS=darwin GOARCH=arm64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-server-darwin-arm64 apps/server/main.go
+          echo "✓ Built vault-hub-server-darwin-arm64"
+          
+          echo "All server binaries built successfully!"
+          echo "Listing built files:"
+          ls -la bin/vault-hub-server-*
       - name: Build CLI Binaries
         run: |
           VERSION=${{ github.ref_name }}
           COMMIT=$(git rev-parse --short HEAD)
           LDFLAGS="-X github.com/lwshen/vault-hub/internal/version.Version=${VERSION} -X github.com/lwshen/vault-hub/internal/version.Commit=${COMMIT}"
           
+          echo "Building CLI binaries with version: $VERSION, commit: $COMMIT"
+          echo "LDFLAGS: $LDFLAGS"
+          
+          # Create bin directory if it doesn't exist
+          mkdir -p bin
+          
           # Linux builds
+          echo "Building CLI Linux AMD64..."
           GOOS=linux GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-linux-amd64 apps/cli/main.go
+          echo "✓ Built vault-hub-cli-linux-amd64"
+          
+          echo "Building CLI Linux ARM64..."
           GOOS=linux GOARCH=arm64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-linux-arm64 apps/cli/main.go
+          echo "✓ Built vault-hub-cli-linux-arm64"
 
           # Windows builds
+          echo "Building CLI Windows AMD64..."
           GOOS=windows GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-windows-amd64.exe apps/cli/main.go
+          echo "✓ Built vault-hub-cli-windows-amd64.exe"
 
           # macOS builds
+          echo "Building CLI macOS AMD64..."
           GOOS=darwin GOARCH=amd64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-darwin-amd64 apps/cli/main.go
+          echo "✓ Built vault-hub-cli-darwin-amd64"
+          
+          echo "Building CLI macOS ARM64..."
           GOOS=darwin GOARCH=arm64 go build -ldflags="$LDFLAGS" -o bin/vault-hub-cli-darwin-arm64 apps/cli/main.go
+          echo "✓ Built vault-hub-cli-darwin-arm64"
+          
+          echo "All CLI binaries built successfully!"
+          echo "Listing built files:"
+          ls -la bin/vault-hub-cli-*
       - name: Upload Release Assets
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,8 +280,13 @@ jobs:
           # Add and commit changelog if there are changes
           git add CHANGELOG.md
           if ! git diff --staged --quiet; then
+            # Create new branch for changelog update
+            BRANCH_NAME="chore/update-changelog-${{ github.ref_name }}"
+            git checkout -b "$BRANCH_NAME"
             git commit -m "chore: update CHANGELOG.md for ${{ github.ref_name }}"
-            git push origin main
+            git push origin "$BRANCH_NAME"
+            echo "Created branch: $BRANCH_NAME"
+            echo "Changelog update pushed to new branch for review"
           else
             echo "No changes to CHANGELOG.md, skipping commit"
           fi

--- a/packages/api/openapi/paths/version.yaml
+++ b/packages/api/openapi/paths/version.yaml
@@ -6,7 +6,7 @@ version:
     tags:
       - Version
     responses:
-      '200':
+      "200":
         description: Version information retrieved successfully
         content:
           application/json:

--- a/packages/api/openapi/schemas/version.yaml
+++ b/packages/api/openapi/schemas/version.yaml
@@ -7,8 +7,8 @@ VersionResponse:
     version:
       type: string
       description: Application version
-      example: "v1.0.0"
+      example: v1.0.0
     commit:
       type: string
       description: Git commit hash
-      example: "abc1234"
+      example: abc1234


### PR DESCRIPTION
## Summary by Sourcery

Enhance the GitHub Actions release workflow by adding verbose build logging, ensuring output directory creation, listing built artifacts across platforms, and refining the changelog commit step to run only when there are changes after checking out main

Build:
- Create bin directory before building server and CLI binaries
- Add echo statements to log version, build steps, and success messages
- List built server and CLI artifacts for Linux, Windows, and macOS

CI:
- Checkout and pull latest main branch before updating changelog
- Make changelog commit and push conditional on staged changes
- Execute conditional logic to skip commit if no changelog updates