### PR TITLE
chore: format yaml

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -49,6 +49,7 @@ jobs:
             - Test coverage
 
             Be constructive and helpful in your feedback.
+
 # Optional: Use sticky comments to make Claude reuse the same comment on subsequent pushes to the same PR
 # use_sticky_comment: true
 # Optional: Customize review based on file types

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -47,6 +47,7 @@ jobs:
           # model: "claude-opus-4-20250514"
           # Optional: Customize the trigger phrase (default: @claude)
           # trigger_phrase: "/claude"
+
 # Optional: Trigger when specific user is assigned to an issue
 # assignee_trigger: "claude-bot"
 

--- a/.github/workflows/publish-ts-client.yml
+++ b/.github/workflows/publish-ts-client.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           node-version: 22.x
           registry-url: https://npm.pkg.github.com
-          scope: '@lwshen'
+          scope: "@lwshen"
       - name: Set env
         run: echo "TAG=0.$(date +'%Y%m%d.%H%M%S')" >> "$GITHUB_ENV"
       - name: Generate Typescript Fetch Client Library

--- a/packages/api/openapi/schemas/apikey.yaml
+++ b/packages/api/openapi/schemas/apikey.yaml
@@ -9,7 +9,7 @@ APIKeysResponse:
     apiKeys:
       type: array
       items:
-        $ref: '#/VaultAPIKey'
+        $ref: "#/VaultAPIKey"
     totalCount:
       type: integer
       description: Total number of API keys
@@ -84,7 +84,7 @@ CreateAPIKeyResponse:
     - key
   properties:
     apiKey:
-      $ref: '#/VaultAPIKey'
+      $ref: "#/VaultAPIKey"
     key:
       type: string
       description: The generated API key (only shown once)

--- a/packages/api/openapi/schemas/audit.yaml
+++ b/packages/api/openapi/schemas/audit.yaml
@@ -9,7 +9,7 @@ AuditLogsResponse:
     auditLogs:
       type: array
       items:
-        $ref: '#/AuditLog'
+        $ref: "#/AuditLog"
     totalCount:
       type: integer
       description: Total number of logs matching the filter criteria


### PR DESCRIPTION
## Summary by Sourcery

Apply consistent YAML formatting across OpenAPI schemas and GitHub workflow files

Chores:
- Standardize quoting style in OpenAPI schema $ref values to use double quotes
- Unify YAML quoting in GitHub workflow configurations and add blank lines for readability