### PR TITLE
chore: update token reference in release workflow (#186)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GH_TOKEN }}
           add-paths: |
             CHANGELOG.md
           labels: |


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Change token input in the release workflow from GITHUB_TOKEN to GH_TOKEN for the create-pull-request step