### PR TITLE
feat(docker): add go-cron binary and update Dockerfile for cron support

### DIFF
--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -16,6 +16,9 @@ RUN go mod download
 
 RUN go build -o vault-hub-cli apps/cli/main.go
 
+# Build cron binary
+RUN go build -o go-cron apps/cron/main.go
+
 FROM alpine:3.22
 
 WORKDIR /app
@@ -24,16 +27,16 @@ WORKDIR /app
 RUN addgroup -g 1001 -S vaultuser && \
     adduser -u 1001 -S vaultuser -G vaultuser
 
-# Install cron and other necessary packages
+# Install necessary packages
 RUN apk add --no-cache \
     ca-certificates \
     tzdata \
-    dcron \
     bash \
     && mkdir -p /var/log/cron \
     && chown -R vaultuser:vaultuser /var/log/cron
 
 COPY --from=cli-builder /app/vault-hub-cli ./
+COPY --from=cli-builder /app/go-cron ./
 
 # Change ownership of app directory
 RUN chown -R vaultuser:vaultuser /app
@@ -48,20 +51,17 @@ RUN_MODE=${RUN_MODE:-"oneshot"}
 
 case "$RUN_MODE" in
   "cron")
-    echo "Starting in cron mode..."
+    echo "Starting in cron mode with go-cron..."
     # Create cron job from CRON_SCHEDULE (default every hour)
     CRON_SCHEDULE=${CRON_SCHEDULE:-"0 * * * *"}
     VAULT_HUB_CLI_ARGS=${VAULT_HUB_CLI_ARGS:-"list"}
-    
-    # Create cron job for vaultuser
-    echo "$CRON_SCHEDULE cd /app && ./vault-hub-cli $VAULT_HUB_CLI_ARGS >> /var/log/cron/vault-hub.log 2>&1" > /etc/crontabs/vaultuser
     
     echo "Cron job scheduled: $CRON_SCHEDULE"
     echo "CLI arguments: $VAULT_HUB_CLI_ARGS"
     echo "Logs will be written to /var/log/cron/vault-hub.log"
     
-    # Start cron daemon
-    crond -f -l 2
+    # Start go-cron with the vault-hub-cli command
+    exec ./go-cron "$CRON_SCHEDULE" /bin/bash -c "cd /app && ./vault-hub-cli $VAULT_HUB_CLI_ARGS >> /var/log/cron/vault-hub.log 2>&1"
     ;;
   "oneshot")
     echo "Running in one-shot mode..."

--- a/apps/cron/main.go
+++ b/apps/cron/main.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/robfig/cron/v3"
+)
+
+func timestampedPrint(prefix, message string) {
+	timestamp := time.Now().Format("2006-01-02 15:04:05")
+	fmt.Printf("[%s] %s: %s", timestamp, prefix, message)
+}
+
+func streamOutput(prefix string, reader io.Reader) {
+	scanner := bufio.NewScanner(reader)
+	for scanner.Scan() {
+		timestampedPrint(prefix, scanner.Text()+"\n")
+	}
+	if err := scanner.Err(); err != nil {
+		timestampedPrint("ERROR", fmt.Sprintf("Error reading output: %v\n", err))
+	}
+}
+
+func validateSchedule(schedule string) error {
+	// Handle @every syntax
+	if strings.HasPrefix(schedule, "@every ") {
+		duration := strings.TrimPrefix(schedule, "@every ")
+		_, err := time.ParseDuration(duration)
+		return err
+	}
+
+	// Handle standard cron syntax and descriptors
+	parser := cron.NewParser(cron.Minute | cron.Hour | cron.Dom | cron.Month | cron.Dow | cron.Descriptor)
+
+	_, err := parser.Parse(schedule)
+	return err
+}
+
+func main() {
+	if len(os.Args) < 3 {
+		fmt.Println("Usage: go-cron <schedule> <command> [args...]")
+		os.Exit(1)
+	}
+
+	schedule := os.Args[1]
+	command := os.Args[2]
+	args := os.Args[3:]
+
+	// Validate schedule
+	if err := validateSchedule(schedule); err != nil {
+		timestampedPrint("ERROR", fmt.Sprintf("Invalid schedule format: %v\n", err))
+		os.Exit(1)
+	}
+
+	// Validate command
+	if _, err := exec.LookPath(command); err != nil {
+		timestampedPrint("ERROR", fmt.Sprintf("Command not found: %s\n", command))
+		os.Exit(1)
+	}
+
+	c := cron.New()
+
+	_, err := c.AddFunc(schedule, func() {
+		timestampedPrint("INFO", fmt.Sprintf("Executing command: %s %v\n", command, args))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
+		defer cancel()
+
+		cmd := exec.CommandContext(ctx, command, args...)
+
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			timestampedPrint("ERROR", fmt.Sprintf("Error creating stdout pipe: %v\n", err))
+			return
+		}
+
+		stderr, err := cmd.StderrPipe()
+		if err != nil {
+			timestampedPrint("ERROR", fmt.Sprintf("Error creating stderr pipe: %v\n", err))
+			return
+		}
+
+		err = cmd.Start()
+		if err != nil {
+			timestampedPrint("ERROR", fmt.Sprintf("Error starting command: %v\n", err))
+			return
+		}
+
+		go streamOutput("STDOUT", stdout)
+		go streamOutput("STDERR", stderr)
+
+		err = cmd.Wait()
+		if err != nil {
+			if ctx.Err() == context.DeadlineExceeded {
+				timestampedPrint("ERROR", "Command timed out after 1 hour\n")
+			} else {
+				timestampedPrint("ERROR", fmt.Sprintf("Command finished with error: %v\n", err))
+			}
+		} else {
+			timestampedPrint("INFO", "Command finished successfully\n")
+		}
+	})
+
+	if err != nil {
+		timestampedPrint("ERROR", fmt.Sprintf("Error adding cron job: %v\n", err))
+		os.Exit(1)
+	}
+
+	timestampedPrint("INFO", fmt.Sprintf("Cron job scheduled: %s\n", schedule))
+	timestampedPrint("INFO", fmt.Sprintf("Command to run: %s %v\n", command, strings.Join(args, " ")))
+
+	c.Run()
+}

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/lwshen/vault-hub-go-client v0.0.20250819101010
 	github.com/oapi-codegen/runtime v1.1.2
 	github.com/orandin/slog-gorm v1.4.0
+	github.com/robfig/cron/v3 v3.0.1
 	github.com/samber/slog-fiber v1.18.0
 	github.com/spf13/cobra v1.9.1
 	golang.org/x/crypto v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
+github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
 github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=


### PR DESCRIPTION
## Summary by Sourcery

Introduce a go-cron binary to the codebase and update the Dockerfile to enable scheduled command execution inside the container via cron.

New Features:
- Introduce go-cron CLI for scheduling and executing commands according to cron expressions or @every durations.

Enhancements:
- Add timestamped logging, real-time stdout/stderr streaming, and timeout/error handling for scheduled jobs.

Build:
- Add robfig/cron/v3 dependency in go.mod/go.sum and update Dockerfile to build and include the go-cron binary in the container image.