### PR TITLE
feat: redirect to dashboard after login and signup

### DIFF
--- a/apps/web/src/components/login-form.tsx
+++ b/apps/web/src/components/login-form.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { PATH } from '@/const/path';
 import { FaOpenid, FaGoogle, FaApple } from 'react-icons/fa';
 import { useLocation } from 'wouter';
 import useAuth from '@/hooks/use-auth';
@@ -37,7 +38,7 @@ export function LoginForm({
     setLoading(true);
     try {
       await login(form.email, form.password);
-      // TODO: handle successful login (e.g., redirect)
+      navigate(PATH.DASHBOARD);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Login failed');
     } finally {

--- a/apps/web/src/components/signup-form.tsx
+++ b/apps/web/src/components/signup-form.tsx
@@ -45,7 +45,7 @@ export function SignupForm({
     setLoading(true);
     try {
       await signup(form.email, form.password, form.name);
-      navigateToLogin();
+      navigate(PATH.DASHBOARD);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Signup failed');
     } finally {
@@ -53,9 +53,6 @@ export function SignupForm({
     }
   };
 
-  const navigateToLogin = () => {
-    navigate(PATH.LOGIN);
-  };
 
   return (
     <div className={cn('flex flex-col gap-6', className)} {...props}>
@@ -127,7 +124,7 @@ export function SignupForm({
               </div>
               <div className="text-center text-sm">
                 Already have an account?{' '}
-                <Button variant="link" onClick={navigateToLogin}>
+                <Button variant="link" onClick={() => navigate(PATH.LOGIN)}>
                   Sign in
                 </Button>
               </div>


### PR DESCRIPTION
## Summary by Sourcery

Redirect users to the dashboard after signup and login, remove the old navigateToLogin function, and update the sign-in link to use inline navigation.

Enhancements:
- Redirect to dashboard on successful signup
- Redirect to dashboard on successful login
- Remove obsolete navigateToLogin helper from signup form
- Simplify the "Sign in" link to use direct navigation to the login path