### PR TITLE
ci: update image tagging strategy in workflows

### DIFF
--- a/.github/workflows/build-cli-image.yml
+++ b/.github/workflows/build-cli-image.yml
@@ -26,7 +26,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
-            type=raw,value=latest,enable={{startsWith(github.ref, 'refs/tags/v')}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -26,7 +26,7 @@ jobs:
           tags: |
             type=ref,event=branch
             type=ref,event=tag
-            type=raw,value=latest,enable={{startsWith(github.ref, 'refs/tags/v')}}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary by Sourcery

Refine Docker image tagging in GitHub Actions workflows to tag images by branch or tag reference and apply the raw “latest” tag only for version tags prefixed with “v”

CI:
- Replace unconditional “latest” tag with conditional raw “latest” for refs starting with “refs/tags/v” in both build-image and build-cli-image workflows
- Add branch reference tagging to both build-image and build-cli-image workflows