### PR TITLE
chore: add versioning support in Dockerfiles and workflows

### DIFF
--- a/.github/workflows/build-cli-image.yml
+++ b/.github/workflows/build-cli-image.yml
@@ -42,3 +42,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
+            COMMIT=${{ github.sha }}

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -42,3 +42,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
+            COMMIT=${{ github.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 ARG NODE_VERSION=22
 ARG GO_VERSION=1.24
+ARG VERSION=dev
+ARG COMMIT=unknown
 
 FROM node:${NODE_VERSION}-alpine AS frontend-builder
 
@@ -29,7 +31,7 @@ COPY --from=frontend-builder /app/dist ./apps/web/dist
 
 RUN go mod download
 
-RUN go build -o vault-hub-server apps/server/main.go
+RUN go build -ldflags="-X github.com/lwshen/vault-hub/internal/version.Version=${VERSION} -X github.com/lwshen/vault-hub/internal/version.Commit=${COMMIT}" -o vault-hub-server apps/server/main.go
 
 FROM alpine:3.22
 

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -1,4 +1,6 @@
 ARG GO_VERSION=1.24
+ARG VERSION=dev
+ARG COMMIT=unknown
 
 FROM golang:${GO_VERSION}-alpine AS cli-builder
 
@@ -14,7 +16,7 @@ COPY . .
 
 RUN go mod download
 
-RUN go build -o vault-hub-cli apps/cli/main.go
+RUN go build -ldflags="-X github.com/lwshen/vault-hub/internal/version.Version=${VERSION} -X github.com/lwshen/vault-hub/internal/version.Commit=${COMMIT}" -o vault-hub-cli apps/cli/main.go
 
 # Build cron binary
 RUN go build -o go-cron apps/cron/main.go


### PR DESCRIPTION
- Introduced VERSION and COMMIT build arguments in Dockerfiles for frontend and CLI.
- Updated build commands to include versioning information.
- Modified GitHub workflows to pass version and commit SHA as build arguments.

## Summary by Sourcery

Add versioning support by introducing VERSION and COMMIT build arguments in Dockerfiles and GitHub workflows, and embed these values into the Go binary using ldflags

Enhancements:
- Embed version and commit SHA into the Go server binary via ldflags

Build:
- Define VERSION and COMMIT ARGs in Dockerfile and Dockerfile-cli

CI:
- Pass VERSION (tag or 'dev') and COMMIT SHA as build-args in build-image and build-cli-image workflows