### PR TITLE
ci: streamline Dockerfiles and workflows for CI/CD integration

### DIFF
--- a/.github/workflows/build-cli-image.yml
+++ b/.github/workflows/build-cli-image.yml
@@ -3,17 +3,24 @@ on:
   workflow_dispatch:
   push:
 jobs:
+  build:
+    uses: ./.github/workflows/ci.yml
+  
   push_to_registry:
     name: Push CLI Docker image to Docker Hub
     runs-on: ubuntu-latest
+    needs: build
     permissions:
       contents: read
       packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v5
+      
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
+          name: vault-hub-server
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-cli-image.yml
+++ b/.github/workflows/build-cli-image.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: vault-hub-server
+          name: vault-hub-binaries
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,17 +3,24 @@ on:
   workflow_dispatch:
   push:
 jobs:
+  build:
+    uses: ./.github/workflows/ci.yml
+  
   push_to_registry:
     name: Push Docker image to Docker Hub
     runs-on: ubuntu-latest
+    needs: build
     permissions:
       contents: read
       packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v5
+      
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
         with:
-          fetch-depth: 0
+          name: vault-hub-server
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v4
         with:
-          name: vault-hub-server
+          name: vault-hub-binaries
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_call:
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: vault-hub-server
+          name: vault-hub-binaries
           path: |
             bin/
             apps/web/dist

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN addgroup -g 1001 -S vaultuser && \
 
 # Copy pre-built binary and frontend assets (expected to be built by CI)
 # Use build arg to determine which binary to copy based on target platform
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 COPY bin/vault-hub-server-linux-${TARGETARCH} ./vault-hub-server
 COPY apps/web/dist ./apps/web/dist
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN addgroup -g 1001 -S vaultuser && \
     adduser -u 1001 -S vaultuser -G vaultuser
 
 # Copy pre-built binary and frontend assets (expected to be built by CI)
-COPY bin/vault-hub-server-linux-amd64 ./vault-hub-server
+# Use build arg to determine which binary to copy based on target platform
+ARG TARGETARCH
+COPY bin/vault-hub-server-linux-${TARGETARCH} ./vault-hub-server
 COPY apps/web/dist ./apps/web/dist
 
 # Change ownership of app directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,38 +1,3 @@
-ARG NODE_VERSION=22
-ARG GO_VERSION=1.24
-
-FROM node:${NODE_VERSION}-alpine AS frontend-builder
-
-WORKDIR /app
-
-COPY apps/web ./
-
-RUN corepack enable
-
-RUN pnpm install --frozen-lockfile
-
-RUN pnpm build
-
-FROM golang:${GO_VERSION}-alpine AS backend-builder
-
-WORKDIR /app
-
-RUN apk add --no-cache gcc libc-dev git
-
-ENV GO111MODULE=on \
-    CGO_ENABLED=1 \
-    GOOS=linux
-
-COPY . .
-
-COPY --from=frontend-builder /app/dist ./apps/web/dist
-
-RUN go mod download
-
-RUN VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo 'dev') && \
-    COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown') && \
-    go build -ldflags="-X github.com/lwshen/vault-hub/internal/version.Version=${VERSION} -X github.com/lwshen/vault-hub/internal/version.Commit=${COMMIT}" -o vault-hub-server apps/server/main.go
-
 FROM alpine:3.22
 
 WORKDIR /app
@@ -41,8 +6,9 @@ WORKDIR /app
 RUN addgroup -g 1001 -S vaultuser && \
     adduser -u 1001 -S vaultuser -G vaultuser
 
-COPY --from=backend-builder /app/vault-hub-server ./
-COPY --from=backend-builder /app/apps/web/dist ./apps/web/dist
+# Copy pre-built binary and frontend assets (expected to be built by CI)
+COPY bin/vault-hub-server-linux-amd64 ./vault-hub-server
+COPY apps/web/dist ./apps/web/dist
 
 # Change ownership of app directory
 RUN chown -R vaultuser:vaultuser /app

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -1,22 +1,17 @@
-ARG GO_VERSION=1.24
-
-FROM golang:${GO_VERSION}-alpine AS cli-builder
+FROM golang:1.24-alpine AS cron-builder
 
 WORKDIR /app
 
-RUN apk add --no-cache gcc libc-dev git
+RUN apk add --no-cache gcc libc-dev
 
 ENV GO111MODULE=on \
     CGO_ENABLED=1 \
     GOOS=linux
 
-COPY . .
+COPY go.mod go.sum ./
+COPY apps/cron ./apps/cron
 
 RUN go mod download
-
-RUN VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo 'dev') && \
-    COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo 'unknown') && \
-    go build -ldflags="-X github.com/lwshen/vault-hub/internal/version.Version=${VERSION} -X github.com/lwshen/vault-hub/internal/version.Commit=${COMMIT}" -o vault-hub-cli apps/cli/main.go
 
 # Build cron binary
 RUN go build -o go-cron apps/cron/main.go
@@ -37,8 +32,9 @@ RUN apk add --no-cache \
     && mkdir -p /var/log/cron \
     && chown -R vaultuser:vaultuser /var/log/cron
 
-COPY --from=cli-builder /app/vault-hub-cli ./
-COPY --from=cli-builder /app/go-cron ./
+# Copy pre-built CLI binary (expected to be built by CI)
+COPY bin/vault-hub-cli-linux-amd64 ./vault-hub-cli
+COPY --from=cron-builder /app/go-cron ./
 
 # Change ownership of app directory
 RUN chown -R vaultuser:vaultuser /app

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -34,7 +34,7 @@ RUN apk add --no-cache \
 
 # Copy pre-built CLI binary (expected to be built by CI)
 # Use build arg to determine which binary to copy based on target platform
-ARG TARGETARCH
+ARG TARGETARCH=amd64
 COPY bin/vault-hub-cli-linux-${TARGETARCH} ./vault-hub-cli
 COPY --from=cron-builder /app/go-cron ./
 

--- a/Dockerfile-cli
+++ b/Dockerfile-cli
@@ -33,7 +33,9 @@ RUN apk add --no-cache \
     && chown -R vaultuser:vaultuser /var/log/cron
 
 # Copy pre-built CLI binary (expected to be built by CI)
-COPY bin/vault-hub-cli-linux-amd64 ./vault-hub-cli
+# Use build arg to determine which binary to copy based on target platform
+ARG TARGETARCH
+COPY bin/vault-hub-cli-linux-${TARGETARCH} ./vault-hub-cli
 COPY --from=cron-builder /app/go-cron ./
 
 # Change ownership of app directory


### PR DESCRIPTION
## Summary by Sourcery

Streamline Dockerfiles by removing multi-stage build stages and delegating binary and asset compilation to a shared CI workflow, and update GitHub Actions workflows to separate build and push steps with artifact handling

Enhancements:
- Simplify Dockerfiles by removing frontend/backend builder stages and copying pre-built binaries and assets based on TARGETARCH
- Add TARGETARCH build argument to support multi-arch Docker images
- Align Dockerfile-cli with the artifact-driven build approach

CI:
- Introduce a reusable build job via .github/workflows/ci.yml for both CLI and app images
- Add 'needs: build' dependencies and artifact download steps in push_to_registry jobs to retrieve vault-hub-server binaries
- Remove inline build steps and reuse common CI workflow for consistency across image builds