### PR TITLE
Build and verify app distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,8 @@ ENV GO111MODULE=on \
 
 COPY . .
 
-COPY --from=frontend-builder /app/dist ./apps/web/dist
+# Copy built frontend into embed path so it is included in the Go binary
+COPY --from=frontend-builder /app/dist ./internal/staticfs/dist
 
 RUN go mod download
 
@@ -42,7 +43,7 @@ RUN addgroup -g 1001 -S vaultuser && \
     adduser -u 1001 -S vaultuser -G vaultuser
 
 COPY --from=backend-builder /app/vault-hub-server ./
-COPY --from=backend-builder /app/apps/web/dist ./apps/web/dist
+# No need to copy dist at runtime; assets are embedded in the binary
 
 # Change ownership of app directory
 RUN chown -R vaultuser:vaultuser /app

--- a/internal/staticfs/dist/index.html
+++ b/internal/staticfs/dist/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>VaultHub</title>
+  </head>
+  <body>
+    <div id="root"></div>
+  </body>
+  <!-- placeholder embedded index; real assets will replace during build -->
+</html>
+

--- a/internal/staticfs/embed.go
+++ b/internal/staticfs/embed.go
@@ -1,0 +1,8 @@
+package staticfs
+
+import "embed"
+
+// WebDist embeds the built web assets from apps/web/dist
+//go:embed all:dist
+var WebDist embed.FS
+

--- a/route/route.go
+++ b/route/route.go
@@ -1,9 +1,14 @@
 package route
 
 import (
-	"github.com/gofiber/fiber/v2"
-	"github.com/lwshen/vault-hub/handler"
-	openapi "github.com/lwshen/vault-hub/packages/api"
+    "io/fs"
+    "path/filepath"
+    "strings"
+
+    "github.com/gofiber/fiber/v2"
+    "github.com/lwshen/vault-hub/handler"
+    "github.com/lwshen/vault-hub/internal/staticfs"
+    openapi "github.com/lwshen/vault-hub/packages/api"
 )
 
 func SetupRoutes(app *fiber.App) {
@@ -19,12 +24,62 @@ func SetupRoutes(app *fiber.App) {
 	auth.Get("/login/oidc", handler.LoginOidc)
 	auth.Get("/callback/oidc", handler.LoginOidcCallback)
 
-	// Web
-	app.Static("/", "./apps/web/dist")
-	app.Get("/*", func(c *fiber.Ctx) error {
-		if err := c.SendFile("./apps/web/dist/index.html"); err != nil {
-			return c.SendStatus(fiber.StatusInternalServerError)
-		}
-		return nil
-	})
+    // Web (embedded)
+    sub, err := fs.Sub(staticfs.WebDist, "dist")
+    if err == nil {
+        app.Get("/*", func(c *fiber.Ctx) error {
+            reqPath := c.Params("*")
+            if reqPath == "" || strings.HasSuffix(reqPath, "/") {
+                reqPath = reqPath + "index.html"
+            }
+
+            // Try to serve the requested asset
+            if f, openErr := sub.Open(reqPath); openErr == nil {
+                defer f.Close()
+                c.Type(contentTypeForPath(reqPath))
+                return c.SendStream(f)
+            }
+
+            // Fallback to SPA index.html
+            f, openErr := sub.Open("index.html")
+            if openErr != nil {
+                return c.SendStatus(fiber.StatusInternalServerError)
+            }
+            defer f.Close()
+            c.Type("html")
+            return c.SendStream(f)
+        })
+    }
+}
+
+func contentTypeForPath(p string) string {
+    ext := strings.ToLower(filepath.Ext(p))
+    switch ext {
+    case ".html":
+        return "html"
+    case ".css":
+        return "css"
+    case ".js":
+        return "javascript"
+    case ".json":
+        return "json"
+    case ".svg":
+        return "svg"
+    case ".png":
+        return "png"
+    case ".jpg", ".jpeg":
+        return "jpeg"
+    case ".ico":
+        return "x-icon"
+    case ".map":
+        return "json"
+    case ".woff":
+        return "font"
+    case ".woff2":
+        return "font"
+    case ".ttf":
+        return "font"
+    default:
+        return "octet-stream"
+    }
 }


### PR DESCRIPTION
Embed the web frontend assets (`apps/web/dist`) directly into the Go backend binary to enable self-contained deployment and serving of the web application.

This change introduces a new `internal/staticfs` package to manage the embedded assets and updates the Fiber router to serve these assets with a Single Page Application (SPA) fallback. The Dockerfile is also adjusted to copy the built frontend into the embed path during the build process.

---
<a href="https://cursor.com/background-agent?bcId=bc-c0bf26a3-15f5-4d3c-a7d0-5d026a9e987e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c0bf26a3-15f5-4d3c-a7d0-5d026a9e987e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

## Summary by Sourcery

Embed the web application's compiled front-end into the Go backend using Go’s embed.FS, update routing to serve these assets with a SPA fallback, and adjust the Docker build to include the embedded files

New Features:
- Embed web frontend assets directly into the Go binary for self-contained deployment
- Serve embedded web assets through the Fiber router with SPA fallback

Enhancements:
- Add internal/staticfs package and embed.FS to manage embedded frontend files
- Implement content-type inference for serving static assets

Build:
- Adjust Dockerfile to copy built frontend assets into the embed directory and remove runtime asset copying