### PR TITLE
chore: update Claude workflows to use ANTHROPIC_API_KEY and add ANTHROPIC_BASE_URL

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -31,10 +31,12 @@ jobs:
       - name: Run Claude Code Review
         id: claude-review
         uses: anthropics/claude-code-action@beta
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           # Comma-separated list of allowed bot usernames, or '*' to allow all bots. Empty string (default) allows no bots.
           allowed_bots: cursor,dependabot
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -35,10 +35,12 @@ jobs:
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@beta
+        env:
+          ANTHROPIC_BASE_URL: ${{ secrets.ANTHROPIC_BASE_URL }}
         with:
           # Comma-separated list of allowed bot usernames, or '*' to allow all bots. Empty string (default) allows no bots.
           allowed_bots: cursor,dependabot
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub workflows for Claude integration to use the new Anthropics API key secret and add support for a customizable base URL.

CI:
- Replace the deprecated CLAUDE_CODE_OAUTH_TOKEN input with the new ANTHROPIC_API_KEY secret in both workflows
- Inject the ANTHROPIC_BASE_URL environment variable into the Claude code and review job steps

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch Claude workflows to use `anthropic_api_key` (and optional `ANTHROPIC_BASE_URL`) instead of `claude_code_oauth_token`.
> 
> - **GitHub Actions**:
>   - `/.github/workflows/claude-code-review.yml`:
>     - Add `env` with `ANTHROPIC_BASE_URL` from secrets.
>     - Replace `claude_code_oauth_token` input with `anthropic_api_key` from secrets; keep `github_token`.
>   - `/.github/workflows/claude.yml`:
>     - Add `env` with `ANTHROPIC_BASE_URL` from secrets.
>     - Replace `claude_code_oauth_token` input with `anthropic_api_key` from secrets; keep `github_token`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c72a4e8161c45478ef76ae6e56435f4ba0137935. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->