### PR TITLE
ci: add mirroring to gitness

### DIFF
--- a/.github/workflows/mirror.yml
+++ b/.github/workflows/mirror.yml
@@ -18,3 +18,17 @@ jobs:
           username: ${{ secrets.GITLAB_USERNAME }}
           gitlab_pat: ${{ secrets.GITLAB_ACCESS_TOKEN }}
           force_push: true
+
+  to_gitness:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: keninkujovic/gitlab-sync@2.2.0
+        with:
+          gitlab_url: https://gitness.zeabur.app/git/vault-hub/vault-hub.git
+          username: ${{ secrets.GITNESS_USERNAME }}
+          gitlab_pat: ${{ secrets.GITNESS_ACCESS_TOKEN }}
+          force_push: true


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Introduce a to_gitness workflow job that syncs the repository to a Gitness Git remote using stored credentials.